### PR TITLE
remove gross rent vars from moe macro list

### DIFF
--- a/Macros/ACS_summary_geo.sas
+++ b/Macros/ACS_summary_geo.sas
@@ -569,8 +569,7 @@
 	   mGrossRent500_549_&_years. mGrossRent550_599_&_years. mGrossRent600_649_&_years. 
 	   mGrossRent650_699_&_years. mGrossRent700_749_&_years. mGrossRent750_799_&_years. 
 	   mGrossRent800_899_&_years. mGrossRent900_999_&_years. mGrossRent1000_1249_&_years. 
-	   mGrossRent1250_1499_&_years. mGrossRent1500_1999_&_years. mGrossRent2000_2499_&_years. 
-	   mGrossRent2500_2999_&_years. mGrossRent3000_3499_&_years. mGrossRentGT3500_&_years. 
+	   mGrossRent1250_1499_&_years. mGrossRent1500_1999_&_years.
 	   mGrossRentNoCash_&_years. 
 
 	   mIncmByRenterCst_LT10K_&_years. mIncmByRenterCst_10_19K_&_years. mIncmByRenterCst_20_34K_&_years. 


### PR DESCRIPTION
@lhendey fyi - some of the new gross rent vars appeared in both &moeallyears and &moe2015plus. This was causing the 2006-10 data to error. I removed the duplicates from &moeallyears. 