### PR TITLE
add internet access table by income race education smartphone access …

### DIFF
--- a/Macros/Acs_sf.sas
+++ b/Macros/Acs_sf.sas
@@ -98,6 +98,9 @@
   06/05/18 Yipeng Su Added tables for pop by sex and age, insurance coverage, family type, earnings for Stanton Commons 
   07/09/18 LH Added B25032 
   08/30/18 RP ADded B25009
+  12/21/18 YS added B28006 B28007 B28004 B28009A B28009B B28009C B28009D B28009E B28009F B28009G B28009H B28009I
+                    B28001
+ 
 **************************************************************************/
 
 /** Macro Acs_sf - Start Definition **/
@@ -149,7 +152,8 @@
 	B25077
 	B25106
 	B25031 B25042 B25068 B05006 B27001 B25095 B25074 B14001 B08119 B25032
-	B25009
+	B25009 B28006 B28007 B28004 B28009A B28009B B28009C B28009D B28009E B28009F B28009G B28009H B28009I
+    B28001
 ,
   
   /** List of table estimate (e:) and margin of error (m:) cells that should be excluded from all data sets **/


### PR DESCRIPTION
…to ACS_sf macro

@rpitingolo I added a few 13-17 ACS internet access tables to the ACS_sf macro. Please review so I can move on to the next step. Thanks!