### PR TITLE
update acs summary files

### DIFF
--- a/Macros/ACS_summary_all.sas
+++ b/Macros/ACS_summary_all.sas
@@ -21,7 +21,10 @@
   years = ,
   
   finalize = Y,
-  revisions = New file.
+  revisions = New file.,
+
+  /** Year for census block group/tract defs. Should be 2010 for 2011 and later ACS releases. **/
+  census_geo_year = 2010,
 
   );
 
@@ -53,15 +56,18 @@
   %end;
   
 
-  **** Create summary files from block group source ****;
+  %if &census_geo_year = 2010 %then %do;
 
   %ACS_summary_geo_source( bg10 )
-
-  **** Create summary files from census tract source ****;
-
   %ACS_summary_geo_source( tr10 )
 
-  **** Create summary files from regional county source ****;
+  %end;
+
+  %else %do;
+  %ACS_summary_geo_source( bg20 )
+  %ACS_summary_geo_source( tr20 )
+
+  %end;
 
   %ACS_summary_geo_source( regcounty )
 

--- a/Macros/ACS_summary_geo.sas
+++ b/Macros/ACS_summary_geo.sas
@@ -32,7 +32,7 @@
   
   %let out_ds = ACS_&_years._&state_ab._sum&source_geo_suffix.&geo_suffix;
 
-  %if %upcase( &source_geo ) = BG00 or %upcase( &source_geo ) = BG10 %then %do;
+  %if %upcase( &source_geo ) = BG00 or %upcase( &source_geo ) = BG10 or %upcase( &source_geo ) = BG20 %then %do;
   
     %** Count and MOE variables for block group data **;
 
@@ -1108,6 +1108,7 @@
   
   %if ( &geo_name = GEO2000 and %upcase( &source_geo_var ) = GEO2000 ) or 
       ( &geo_name = GEO2010 and %upcase( &source_geo_var ) = GEO2010 ) or
+	  ( &geo_name = GEO2020 and %upcase( &source_geo_var ) = GEO2020 ) or
     ( &geo_name = COUNTY and %upcase( &source_geo_var ) = REGCOUNTY )%then %do;
 
 	    ** Census tracts from census tract source (same year): just recopy selected vars **;

--- a/Macros/ACS_summary_geo_source.sas
+++ b/Macros/ACS_summary_geo_source.sas
@@ -106,36 +106,63 @@
   %if &_state_ab = dc and (
     %upcase( &source_geo ) = BG00 or
     %upcase( &source_geo ) = BG10 or 
-	%upcase( &source_geo ) = BG20 or 
     %upcase( &source_geo ) = TR00 or
-	%upcase( &source_geo ) = TR10 or
+	%upcase( &source_geo ) = TR10 ) %then %do; 
+
+	
+  %** For DC, do full set of geographies **;
+
+	    %ACS_summary_geo( anc2002, &source_geo )
+	    %ACS_summary_geo( anc2012, &source_geo )
+	    %ACS_summary_geo( city, &source_geo )
+	    %ACS_summary_geo( cluster_tr2000, &source_geo )
+	    %ACS_summary_geo( eor, &source_geo )
+	    %ACS_summary_geo( psa2004, &source_geo )
+	    %ACS_summary_geo( psa2012, &source_geo )
+	    %ACS_summary_geo( psa2019, &source_geo )
+	    %ACS_summary_geo( geo2000, &source_geo ) 
+	    %ACS_summary_geo( geo2010, &source_geo ) 
+	    %ACS_summary_geo( geo2020, &source_geo )
+	    %ACS_summary_geo( voterpre2012, &source_geo )
+	    %ACS_summary_geo( ward2002, &source_geo )
+	    %ACS_summary_geo( ward2012, &source_geo )
+	    %ACS_summary_geo( ward2022, &source_geo )
+	    %ACS_summary_geo( zip, &source_geo )
+	    %ACS_summary_geo( cluster2000, &source_geo )
+	    %ACS_summary_geo( cluster2017, &source_geo )
+	    %ACS_summary_geo( bridgepk, &source_geo )
+	    %ACS_summary_geo( stantoncommons, &source_geo )
+	    %ACS_summary_geo( npa2019, &source_geo )
+
+ 	 %end;
+	
+	
+    %else %if &_state_ab = dc and (
+    %upcase( &source_geo ) = BG20 or  
     %upcase( &source_geo ) = TR20 ) %then %do; 
 
     %** For DC, do full set of geographies **;
-    
-    %ACS_summary_geo( anc2002, &source_geo )
-    %ACS_summary_geo( anc2012, &source_geo )
-    %ACS_summary_geo( city, &source_geo )
-    %ACS_summary_geo( cluster_tr2000, &source_geo )
-    %ACS_summary_geo( eor, &source_geo )
-    %ACS_summary_geo( psa2004, &source_geo )
-    %ACS_summary_geo( psa2012, &source_geo )
-	%ACS_summary_geo( psa2019, &source_geo )
-    %ACS_summary_geo( geo2000, &source_geo )
-    %ACS_summary_geo( geo2010, &source_geo )
-	%ACS_summary_geo( geo2020, &source_geo )
-    %ACS_summary_geo( voterpre2012, &source_geo )
-    %ACS_summary_geo( ward2002, &source_geo )
-    %ACS_summary_geo( ward2012, &source_geo )
-	%ACS_summary_geo( ward2022, &source_geo )
-    %ACS_summary_geo( zip, &source_geo )
-    %ACS_summary_geo( cluster2000, &source_geo )
-	%ACS_summary_geo( cluster2017, &source_geo )
-    %ACS_summary_geo( bridgepk, &source_geo )
-	%ACS_summary_geo( stantoncommons, &source_geo )
-	%ACS_summary_geo( npa2019, &source_geo )
 
-  %end;
+	    %ACS_summary_geo( anc2002, &source_geo )
+	    %ACS_summary_geo( anc2012, &source_geo )
+	    %ACS_summary_geo( city, &source_geo )
+	    %ACS_summary_geo( cluster_tr2000, &source_geo )
+	    %ACS_summary_geo( psa2004, &source_geo )
+	    %ACS_summary_geo( psa2012, &source_geo )
+	    %ACS_summary_geo( psa2019, &source_geo )
+	    %ACS_summary_geo( geo2020, &source_geo )
+	    %ACS_summary_geo( voterpre2012, &source_geo )
+	    %ACS_summary_geo( ward2002, &source_geo )
+	    %ACS_summary_geo( ward2012, &source_geo )
+	    %ACS_summary_geo( ward2022, &source_geo )
+	    %ACS_summary_geo( zip, &source_geo )
+	    %ACS_summary_geo( cluster2000, &source_geo )
+	    %ACS_summary_geo( cluster2017, &source_geo )
+	    %ACS_summary_geo( bridgepk, &source_geo )
+	    %ACS_summary_geo( stantoncommons, &source_geo )
+	    %ACS_summary_geo( npa2019, &source_geo )
+
+ 	 %end;
 
   %else  %if &_state_ab = dc and %upcase( &source_geo ) = REGCOUNTY %then %do;
   %ACS_summary_geo( County, &source_geo )
@@ -150,7 +177,7 @@
     %end;
     %else %if %upcase( &source_geo ) = TR10 %then %do; 
       %ACS_summary_geo( geo2010, &source_geo )
-    %ACS_summary_geo( councildist, &source_geo )
+      %ACS_summary_geo( councildist, &source_geo )
     %end;
     %else %if %upcase( &source_geo ) = TR00 %then %do;
       %ACS_summary_geo( geo2000, &source_geo )

--- a/Macros/ACS_summary_geo_source.sas
+++ b/Macros/ACS_summary_geo_source.sas
@@ -94,7 +94,7 @@
     %ACS_summary_geo_source_bg_vars()
     
     %if %upcase( &source_geo ) = TR00 or %upcase( &source_geo ) = TR10 or 
-        %upcase( &source_geo ) = TR20 %upcase( &source_geo ) = REGCOUNTY 
+        %upcase( &source_geo ) = TR20 or %upcase( &source_geo ) = REGCOUNTY 
       %then %do;
       
         ** Tract/county level variables **;

--- a/Macros/ACS_summary_geo_source.sas
+++ b/Macros/ACS_summary_geo_source.sas
@@ -46,6 +46,20 @@
      %let source_ds = Acs_sf_&_years._&_state_ab._tr10;
      %let source_geo_label = Census tract;
   %end;
+  %else %if %upcase( &source_geo ) = BG20 %then %do;
+     %let source_geo_var = GeoBg2020;
+     %let source_geo_suffix = _bg;
+     %let source_geo_wt_file_fmt = $geobw2f.;
+     %let source_ds = Acs_sf_&_years._&_state_ab._bg20;
+     %let source_geo_label = Block group;
+  %end;
+  %else %if %upcase( &source_geo ) = TR20 %then %do;
+     %let source_geo_var = Geo2020;
+     %let source_geo_suffix = _tr;
+     %let source_geo_wt_file_fmt = $geotw2f.;
+     %let source_ds = Acs_sf_&_years._&_state_ab._tr20;
+     %let source_geo_label = Census tract;
+  %end;
   %else %if %upcase( &source_geo ) = REGCOUNTY %then %do;
      %let source_geo_var = RegCounty;
      %let source_geo_suffix = _regcnt;
@@ -80,7 +94,7 @@
     %ACS_summary_geo_source_bg_vars()
     
     %if %upcase( &source_geo ) = TR00 or %upcase( &source_geo ) = TR10 or 
-        %upcase( &source_geo ) = REGCOUNTY 
+        %upcase( &source_geo ) = TR20 %upcase( &source_geo ) = REGCOUNTY 
       %then %do;
       
         ** Tract/county level variables **;
@@ -92,8 +106,10 @@
   %if &_state_ab = dc and (
     %upcase( &source_geo ) = BG00 or
     %upcase( &source_geo ) = BG10 or 
+	%upcase( &source_geo ) = BG20 or 
     %upcase( &source_geo ) = TR00 or
-    %upcase( &source_geo ) = TR10 ) %then %do; 
+	%upcase( &source_geo ) = TR10 or
+    %upcase( &source_geo ) = TR20 ) %then %do; 
 
     %** For DC, do full set of geographies **;
     
@@ -107,9 +123,11 @@
 	%ACS_summary_geo( psa2019, &source_geo )
     %ACS_summary_geo( geo2000, &source_geo )
     %ACS_summary_geo( geo2010, &source_geo )
+	%ACS_summary_geo( geo2020, &source_geo )
     %ACS_summary_geo( voterpre2012, &source_geo )
     %ACS_summary_geo( ward2002, &source_geo )
     %ACS_summary_geo( ward2012, &source_geo )
+	%ACS_summary_geo( ward2022, &source_geo )
     %ACS_summary_geo( zip, &source_geo )
     %ACS_summary_geo( cluster2000, &source_geo )
 	%ACS_summary_geo( cluster2017, &source_geo )
@@ -126,7 +144,11 @@
   %else %do;
     %** For non-DC, do census tract, council district and county summary file **;
     
-    %if %upcase( &source_geo ) = TR10 %then %do; 
+	%if %upcase( &source_geo ) = TR20 %then %do; 
+      %ACS_summary_geo( geo2020, &source_geo )
+    %ACS_summary_geo( councildist, &source_geo )
+    %end;
+    %else %if %upcase( &source_geo ) = TR10 %then %do; 
       %ACS_summary_geo( geo2010, &source_geo )
     %ACS_summary_geo( councildist, &source_geo )
     %end;

--- a/Macros/ACS_summary_geo_source.sas
+++ b/Macros/ACS_summary_geo_source.sas
@@ -146,7 +146,7 @@
     
 	%if %upcase( &source_geo ) = TR20 %then %do; 
       %ACS_summary_geo( geo2020, &source_geo )
-    %ACS_summary_geo( councildist, &source_geo )
+    %** %ACS_summary_geo( councildist, &source_geo )**;
     %end;
     %else %if %upcase( &source_geo ) = TR10 %then %do; 
       %ACS_summary_geo( geo2010, &source_geo )

--- a/Macros/ACS_summary_geo_source.sas
+++ b/Macros/ACS_summary_geo_source.sas
@@ -68,7 +68,7 @@
      %let source_geo_label = Regional county;
   %end;
   %else %do;
-    %err_mput( macro= ACS_summary_geo_source, msg=Geograpy &source_geo is not supported. )
+    %err_mput( macro= ACS_summary_geo_source, msg=Geography &source_geo is not supported. )
     %goto macro_exit;
   %end;
      

--- a/Prog/SF_2016_20/ACS_2016_20_dc_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_dc_sum_all.sas
@@ -1,0 +1,33 @@
+/**************************************************************************
+ Program:  ACS_2016_20_DC_sum_all.sas
+ Library:  ACS
+ Project:  Urban-Greater DC
+ Author:   Elizabeth Burton
+ Created:  01/25/2023
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ 
+ Description:  Create all standard summary files from ACS 5-year data.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( ACS )
+
+
+%ACS_summary_all( 
+
+  /** State abbreviation. Ex: DC **/
+  state_ab = DC,
+
+  /** Year range (xxxx_yy). Ex: 2005_09 **/
+  years = 2016_20,
+  
+  /** Description of latest file revisions for metadata **/
+  revisions = %str(New file.)
+
+)
+

--- a/Prog/SF_2016_20/ACS_2016_20_dc_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_dc_sum_all.sas
@@ -23,6 +23,9 @@
   /** State abbreviation. Ex: DC **/
   state_ab = DC,
 
+   /** Census geographies used **/
+  census_geo_year=2020,
+
   /** Year range (xxxx_yy). Ex: 2005_09 **/
   years = 2016_20,
   

--- a/Prog/SF_2016_20/ACS_2016_20_md_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_md_sum_all.sas
@@ -23,6 +23,9 @@
   /** State abbreviation. Ex: DC **/
   state_ab = MD,
 
+  /** Census geographies used **/
+  census_geo_year=2020,
+
   /** Year range (xxxx_yy). Ex: 2005_09 **/
   years = 2016_20,
   

--- a/Prog/SF_2016_20/ACS_2016_20_md_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_md_sum_all.sas
@@ -1,0 +1,33 @@
+/**************************************************************************
+ Program:  ACS_2016_20_DC_sum_all.sas
+ Library:  ACS
+ Project:  Urban-Greater DC
+ Author:   Elizabeth Burton
+ Created:  01/25/2023
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ 
+ Description:  Create all standard summary files from ACS 5-year data.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( ACS )
+
+
+%ACS_summary_all( 
+
+  /** State abbreviation. Ex: DC **/
+  state_ab = MD,
+
+  /** Year range (xxxx_yy). Ex: 2005_09 **/
+  years = 2016_20,
+  
+  /** Description of latest file revisions for metadata **/
+  revisions = %str(New file.)
+
+)
+

--- a/Prog/SF_2016_20/ACS_2016_20_md_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_md_sum_all.sas
@@ -1,5 +1,5 @@
 /**************************************************************************
- Program:  ACS_2016_20_DC_sum_all.sas
+ Program:  ACS_2016_20_MD_sum_all.sas
  Library:  ACS
  Project:  Urban-Greater DC
  Author:   Elizabeth Burton

--- a/Prog/SF_2016_20/ACS_2016_20_va_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_va_sum_all.sas
@@ -23,6 +23,9 @@
   /** State abbreviation. Ex: DC **/
   state_ab = VA,
 
+  /** Census geographies used **/
+  census_geo_year=2020,
+
   /** Year range (xxxx_yy). Ex: 2005_09 **/
   years = 2016_20,
   

--- a/Prog/SF_2016_20/ACS_2016_20_va_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_va_sum_all.sas
@@ -1,5 +1,5 @@
 /**************************************************************************
- Program:  ACS_2016_20_DC_sum_all.sas
+ Program:  ACS_2016_20_VA_sum_all.sas
  Library:  ACS
  Project:  Urban-Greater DC
  Author:   Elizabeth Burton

--- a/Prog/SF_2016_20/ACS_2016_20_va_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_va_sum_all.sas
@@ -1,0 +1,33 @@
+/**************************************************************************
+ Program:  ACS_2016_20_DC_sum_all.sas
+ Library:  ACS
+ Project:  Urban-Greater DC
+ Author:   Elizabeth Burton
+ Created:  01/25/2023
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ 
+ Description:  Create all standard summary files from ACS 5-year data.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( ACS )
+
+
+%ACS_summary_all( 
+
+  /** State abbreviation. Ex: DC **/
+  state_ab = VA,
+
+  /** Year range (xxxx_yy). Ex: 2005_09 **/
+  years = 2016_20,
+  
+  /** Description of latest file revisions for metadata **/
+  revisions = %str(New file.)
+
+)
+

--- a/Prog/SF_2016_20/ACS_2016_20_wv_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_wv_sum_all.sas
@@ -1,5 +1,5 @@
 /**************************************************************************
- Program:  ACS_2016_20_DC_sum_all.sas
+ Program:  ACS_2016_20_WV_sum_all.sas
  Library:  ACS
  Project:  Urban-Greater DC
  Author:   Elizabeth Burton

--- a/Prog/SF_2016_20/ACS_2016_20_wv_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_wv_sum_all.sas
@@ -23,6 +23,9 @@
   /** State abbreviation. Ex: DC **/
   state_ab = WV,
 
+  /** Census geographies used **/
+  census_geo_year=2020,
+
   /** Year range (xxxx_yy). Ex: 2005_09 **/
   years = 2016_20,
   

--- a/Prog/SF_2016_20/ACS_2016_20_wv_sum_all.sas
+++ b/Prog/SF_2016_20/ACS_2016_20_wv_sum_all.sas
@@ -1,0 +1,33 @@
+/**************************************************************************
+ Program:  ACS_2016_20_DC_sum_all.sas
+ Library:  ACS
+ Project:  Urban-Greater DC
+ Author:   Elizabeth Burton
+ Created:  01/25/2023
+ Version:  SAS 9.4
+ Environment:  Local Windows session (desktop)
+ 
+ Description:  Create all standard summary files from ACS 5-year data.
+ 
+ Modifications:
+**************************************************************************/
+
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
+
+** Define libraries **;
+%DCData_lib( ACS )
+
+
+%ACS_summary_all( 
+
+  /** State abbreviation. Ex: DC **/
+  state_ab = WV,
+
+  /** Year range (xxxx_yy). Ex: 2005_09 **/
+  years = 2016_20,
+  
+  /** Description of latest file revisions for metadata **/
+  revisions = %str(New file.)
+
+)
+


### PR DESCRIPTION
@rpitingolo updating the sum_all programs for all 4 states. i think there are geography issues with these programs as well. i looked into the acs_summary_all macro (whcih the sum_all programs call) and it calls:  %ACS_summary_geo_source( bg10 ) **** Create summary files from census tract source ****; %ACS_summary_geo_source( tr10 ) and then when i go into that macro that has a lot of 2020 geographies missing... are you able to update these macros? cc @lhendey 