### PR TITLE
Jenner compatibility tests for 5 script(s)

### DIFF
--- a/jenner-check/README.md
+++ b/jenner-check/README.md
@@ -1,0 +1,66 @@
+# Jenner compatibility tests
+
+[Jenner](https://jenneranalytics.com) is a complete SAS-compatible system
+and collaborative workspace. Each `tNNN_*` directory in this folder is a
+self-contained test bundle that submits a SAS program to the public API
+at `https://api.jenneranalytics.com/v1/run` and checks the response.
+
+## Bundle layout
+
+```
+tNNN_*/
+├── script.sas      # the SAS program
+├── autoexec.sas    # options + setup that prepend the script
+├── input/          # sample data the script reads (if any)
+├── expected.json   # stable assertions checked on each run
+├── expected/       # captured snapshot from the last passing run
+│   ├── log.txt     # the .log field, verbatim
+│   ├── output.txt  # the .output (listing) field, verbatim
+│   └── files.md    # links to ODS images, datasets, etc.
+└── meta.json       # provenance: source file, blob sha, what was adapted
+```
+
+## Running a bundle
+
+The runner concatenates `autoexec.sas` + `script.sas`, POSTs to
+`https://api.jenneranalytics.com/v1/run`, and prints the result.
+
+**Mac / Linux (bash + curl):**
+
+```bash
+./run_jenner.sh --all              # run every tNNN_* bundle, summary at end
+./run_jenner.sh t001_something     # run one
+./run_jenner.sh --list             # list bundles in this directory
+```
+
+**Windows:**
+
+```cmd
+run_jenner.bat tNNN_something
+```
+
+**From any SAS session (no curl needed):**
+
+Submit `run_jenner.sas` — it uses PROC HTTP to POST and prints the
+response.
+
+**By hand with curl:**
+
+```bash
+cat tNNN_*/autoexec.sas tNNN_*/script.sas > /tmp/submit.sas
+curl -sS -X POST https://api.jenneranalytics.com/v1/run \
+  -F "script=@/tmp/submit.sas" \
+  -F "deterministic=1" -F "timeout=60"
+```
+
+**Or in the hosted workspace:**
+
+Open <https://jenneranalytics.com>, paste `script.sas` (with the
+`autoexec.sas` lines prepended), upload anything in `input/`, and run.
+
+## Artifact URLs
+
+`expected/files.md` in each bundle lists hosted URLs for any ODS images,
+datasets, or other artifacts produced by a captured run. Those URLs are
+tied to a specific run and expire when the run is reaped — re-run the
+bundle to refresh them.

--- a/jenner-check/run_jenner.sas
+++ b/jenner-check/run_jenner.sas
@@ -1,0 +1,526 @@
+/* run_jenner.sas — invoke api.jenneranalytics.com from base SAS.
+ *
+ * Requires SAS 9.4 M5 or later (PROC HTTP + libname JSON engine).
+ *
+ * ---------------------------------------------------------------------------
+ * TL;DR for SAS users:
+ *
+ *     %include 'run_jenner.sas';
+ *     %jenner_run(script=my_program.sas);              / * one script * /
+ *     %jenner_check_all();                             / * whole bundle dir * /
+ *
+ * ---------------------------------------------------------------------------
+ * What this file gives you:
+ *
+ *   %jenner_run         — POST one .sas file to the Jenner API, display the
+ *                         log + listing + any generated files.
+ *   %jenner_check_all   — walk every jenner-check/tNNN_* bundle,
+ *                         invoke the API for each, compare the response to
+ *                         the bundle's expected.json, produce a summary
+ *                         CSV + SAS dataset the repo owner can attach to the
+ *                         jenner-check PR.
+ *
+ * ---------------------------------------------------------------------------
+ * How the API call is built:
+ *
+ *   POST https://api.jenneranalytics.com/v1/run
+ *   Content-Type: multipart/form-data; boundary=...
+ *
+ *   fields:
+ *     script          the .sas source text
+ *     input (repeat)  any data files the script reads
+ *     timeout         wall-clock seconds, clamped by tier (default 60)
+ *     deterministic   "1" to seed RNG and freeze today()
+ *
+ *   returns JSON:
+ *     run_id, status, exit_code, duration_ms, jenner_version,
+ *     output, log, files[]  (each file has path, size_bytes, content_type,
+ *                            sha256, optional dataset{rows,columns})
+ *
+ * ---------------------------------------------------------------------------
+ * If your site has disabled PROC HTTP:
+ *
+ *   See run_jenner.bat (Windows) or run_jenner.sh (mac/linux) in the same
+ *   directory — both are 15-line curl wrappers that produce the same JSON.
+ *   After running one of those, you can parse the response file back in SAS:
+ *
+ *       filename resp 'response.json';
+ *       libname  resp JSON fileref=resp;
+ *       proc print data=resp.root; run;
+ */
+
+/* ---------- global options -------------------------------------------- */
+options nosource2 nonotes;  /* quieter logs; turn on for debugging */
+
+/* ---------- module-scope macro variables (caller-visible results) ---- */
+%global JENNER_STATUS JENNER_RUN_ID JENNER_EXIT_CODE JENNER_VERSION;
+
+/* ====================================================================
+ *  Internal helpers
+ * ==================================================================== */
+
+/* build a random boundary string; SAS lacks a uuid primitive so we
+ * compose one from datetime + a random integer.                        */
+%macro _jc_boundary;
+  jc_%sysfunc(compress(%sysfunc(datetime(), b8601dt.), -:.))_%sysfunc(ranuni(0),hex6.)
+%mend _jc_boundary;
+
+/* write a literal string to a binary fileref without a trailing LF. */
+%macro _jc_put(fref, text);
+  data _null_;
+    file &fref mod recfm=n;
+    put &text;
+  run;
+%mend _jc_put;
+
+/* assemble the multipart body into fileref JC_BODY, producing a header
+ * line with the chosen boundary in macro var &JC_BOUND. Inputs is a
+ * space-separated list of file paths.
+ *
+ * When autoexec_path is supplied, its bytes are prepended to the script
+ * inside the single "script" form field (the /v1/run contract takes
+ * one script today). A newline separates the two so statements don't
+ * run together. */
+%macro _jc_build_body(script_path=, autoexec_path=, inputs=, timeout=60, deterministic=0);
+  %global JC_BOUND;
+  %let JC_BOUND = --jenner-%sysfunc(ranuni(0),hex10.)--;
+
+  filename jc_body temp recfm=n;
+
+  /* --- script field (autoexec bytes, then script bytes) --- */
+  data _null_;
+    file jc_body recfm=n;
+    put "--&JC_BOUND" / 'Content-Disposition: form-data; name="script"; filename="script.sas"' /
+        'Content-Type: application/x-sas' / ;
+  run;
+  %if %length(&autoexec_path) > 0 %then %do;
+    data _null_;
+      infile "&autoexec_path" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;  /* separator newline */
+    run;
+  %end;
+  /* append raw script bytes */
+  data _null_;
+    infile "&script_path" recfm=n;
+    file jc_body mod recfm=n;
+    input;
+    put _infile_;
+  run;
+  data _null_;
+    file jc_body mod recfm=n;
+    put ;
+  run;
+
+  /* --- optional input files --- */
+  %local i f;
+  %let i = 1;
+  %do %while (%scan(&inputs, &i, %str( )) ne );
+    %let f = %scan(&inputs, &i, %str( ));
+    data _null_;
+      file jc_body mod recfm=n;
+      fname = scan("&f", -1, '/\');
+      put "--&JC_BOUND" /
+          'Content-Disposition: form-data; name="input"; filename="' fname +(-1) '"' /
+          'Content-Type: application/octet-stream' / ;
+    run;
+    data _null_;
+      infile "&f" recfm=n;
+      file jc_body mod recfm=n;
+      input;
+      put _infile_;
+    run;
+    data _null_;
+      file jc_body mod recfm=n;
+      put ;
+    run;
+    %let i = %eval(&i + 1);
+  %end;
+
+  /* --- timeout + deterministic fields --- */
+  data _null_;
+    file jc_body mod recfm=n;
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="timeout"' / /
+        "&timeout";
+    put "--&JC_BOUND" /
+        'Content-Disposition: form-data; name="deterministic"' / /
+        "&deterministic";
+    put "--&JC_BOUND--";
+  run;
+%mend _jc_build_body;
+
+
+/* ====================================================================
+ *  %jenner_run — submit one script, display results.
+ * ==================================================================== */
+%macro jenner_run(
+    script=,
+    autoexec=,
+    inputs=,
+    host=api.jenneranalytics.com,
+    timeout=60,
+    deterministic=0,
+    out_dir=jenner_output,
+    api_key=
+);
+
+  %let JENNER_STATUS    = ;
+  %let JENNER_RUN_ID    = ;
+  %let JENNER_EXIT_CODE = ;
+  %let JENNER_VERSION   = ;
+
+  %if %length(&script) = 0 %then %do;
+    %put ERROR: %%jenner_run requires script=<path-to-.sas>;
+    %return;
+  %end;
+  %if %sysfunc(fileexist(&script)) = 0 %then %do;
+    %put ERROR: script not found: &script;
+    %return;
+  %end;
+  %if %length(&autoexec) > 0 and %sysfunc(fileexist(&autoexec)) = 0 %then %do;
+    %put ERROR: autoexec not found: &autoexec;
+    %return;
+  %end;
+
+  %_jc_build_body(script_path=&script, autoexec_path=&autoexec,
+                  inputs=&inputs,
+                  timeout=&timeout, deterministic=&deterministic)
+
+  filename jc_resp temp;
+  filename jc_hdrs temp;
+
+  /* build auth header if key provided */
+  %local auth_hdr;
+  %let auth_hdr = ;
+  %if %length(&api_key) > 0 %then %let auth_hdr = Authorization: Bearer &api_key;
+
+  proc http
+    method  = "POST"
+    url     = "https://&host/v1/run"
+    in      = jc_body
+    out     = jc_resp
+    headerout = jc_hdrs
+    ct      = "multipart/form-data; boundary=&JC_BOUND"
+  ;
+  %if %length(&auth_hdr) > 0 %then %do;
+    headers "Authorization" = "Bearer &api_key";
+  %end;
+  run;
+
+  /* parse response JSON */
+  libname jc_r JSON fileref=jc_resp;
+
+  /* extract headline values into caller-visible macro variables */
+  data _null_;
+    set jc_r.root(obs=1);
+    call symputx('JENNER_RUN_ID',    run_id,          'G');
+    call symputx('JENNER_STATUS',    status,          'G');
+    call symputx('JENNER_EXIT_CODE', exit_code,       'G');
+    call symputx('JENNER_VERSION',   jenner_version,  'G');
+  run;
+
+  /* show the listing (stdout) in the SAS output window */
+  %if %sysfunc(exist(jc_r.root)) %then %do;
+    data _null_;
+      set jc_r.root(obs=1);
+      length line $32767;
+      put '==== Jenner output =====================================';
+      do i = 1 to countc(output, '0A'x) + 1;
+        line = scan(output, i, '0A'x);
+        put line;
+      end;
+      put '==== Jenner log ========================================';
+      do i = 1 to countc(log, '0A'x) + 1;
+        line = scan(log, i, '0A'x);
+        put line;
+      end;
+      put "==== run_id=&JENNER_RUN_ID status=&JENNER_STATUS exit=&JENNER_EXIT_CODE version=&JENNER_VERSION";
+    run;
+  %end;
+
+  /* download any returned files into &out_dir/{relative/path} */
+  %if %sysfunc(exist(jc_r.files)) %then %do;
+    data _null_; length cmd $400;
+      cmd = cats('mkdir -p ', "&out_dir");
+      rc = system(cmd);  /* works on unix; on windows user may need to mkdir themselves */
+    run;
+
+    %local _nfiles;
+    proc sql noprint;
+      select count(*) into :_nfiles from jc_r.files;
+    quit;
+
+    %local i fpath furl;
+    %do i = 1 %to &_nfiles;
+      data _null_;
+        set jc_r.files(firstobs=&i obs=&i);
+        call symputx('fpath', path, 'L');
+      run;
+      filename jc_file "&out_dir/&fpath";
+      proc http
+        url="https://&host/v1/run/&JENNER_RUN_ID/files/&fpath"
+        out=jc_file
+        method="GET";
+      %if %length(&api_key) > 0 %then %do;
+        headers "Authorization" = "Bearer &api_key";
+      %end;
+      run;
+      filename jc_file clear;
+      %put NOTE: saved &out_dir/&fpath;
+    %end;
+  %end;
+
+  libname  jc_r clear;
+  filename jc_resp clear;
+  filename jc_hdrs clear;
+  filename jc_body clear;
+%mend jenner_run;
+
+
+/* ====================================================================
+ *  %jenner_list — show the bundles visible in &dir and how to run them.
+ *                  Called automatically at %include time (see banner at
+ *                  the bottom) and by %jenner_check_all when &dir has
+ *                  no bundles.
+ * ==================================================================== */
+%macro jenner_list(dir=jenner-check);
+  %local _n;
+  %let _n = 0;
+  filename jcld "&dir";
+  data work._jc_list;
+    length bundle $256;
+    did = dopen('jcld');
+    if did = 0 then do;
+      call symputx('_n', -1, 'L');
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name,1,1) = 't' then do;
+        bundle = name;
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcld clear;
+
+  %if &_n = -1 %then %do;
+    %put NOTE: No directory '&dir' — are you at the repo root? Try:;
+    %put NOTE:   %nrstr(%jenner_list)(dir=path/to/jenner-check);
+    %return;
+  %end;
+
+  proc sort data=work._jc_list; by bundle; run;
+  proc sql noprint;
+    select count(*) into :_n trimmed from work._jc_list;
+  quit;
+
+  %if &_n = 0 %then %do;
+    %put NOTE: No tNNN_* bundles found in '&dir'.;
+    %return;
+  %end;
+
+  %put;
+  %put ======================================================================;
+  %put &_n bundle(s) in &dir:;
+  data _null_;
+    set work._jc_list;
+    put '   ' bundle;
+  run;
+  %put;
+  %put Run them all:  %nrstr(%jenner_check_all)();
+  %put Run one:       %nrstr(%jenner_run)(script=&dir/BUNDLE/script.sas, autoexec=&dir/BUNDLE/autoexec.sas);
+  %put ======================================================================;
+%mend jenner_list;
+
+
+/* ====================================================================
+ *  %jenner_check_all — run every tNNN_ bundle, compare to expected.json,
+ *                      write a CSV summary the owner can attach to the PR.
+ * ==================================================================== */
+%macro jenner_check_all(
+    dir=jenner-check,
+    host=api.jenneranalytics.com,
+    api_key=,
+    report=jenner_check_report.csv
+);
+
+  /* enumerate tNNN_* subdirs */
+  filename jcd "&dir";
+  data work.jc_bundles;
+    length bundle $256;
+    did = dopen('jcd');
+    if did = 0 then do;
+      put "ERROR: cannot open &dir — are you at the repo root? Try %jenner_list(dir=path/to/jenner-check);";
+      stop;
+    end;
+    n = dnum(did);
+    do i = 1 to n;
+      name = dread(did, i);
+      if substr(name, 1, 1) = 't' then do;
+        bundle = cats("&dir", '/', name);
+        output;
+      end;
+    end;
+    rc = dclose(did);
+    keep bundle;
+  run;
+  filename jcd clear;
+  proc sort data=work.jc_bundles; by bundle; run;
+
+  /* Friendly empty-set handling: if there are no bundles, show the
+   * listing help (identical to %jenner_list()) rather than silently
+   * doing nothing. */
+  %local _any;
+  proc sql noprint; select count(*) into :_any trimmed from work.jc_bundles; quit;
+  %if &_any = 0 %then %do;
+    %put NOTE: No tNNN_* bundles under '&dir'. Nothing to run.;
+    %jenner_list(dir=&dir)
+    %return;
+  %end;
+
+  /* result accumulator */
+  data work.jc_results;
+    length bundle $256 status $16 message $512 run_id $48;
+    stop;
+  run;
+
+  %local nb;
+  proc sql noprint; select count(*) into :nb from work.jc_bundles; quit;
+
+  %local i b;
+  %do i = 1 %to &nb;
+    data _null_;
+      set work.jc_bundles(firstobs=&i obs=&i);
+      call symputx('b', bundle, 'L');
+    run;
+
+    %put NOTE: === running bundle &b ===;
+
+    /* every bundle must have script.sas; autoexec.sas is optional
+     * jenner-check bookkeeping (e.g. `options obs=100;` + any owner
+     * autoexec inlined). If present we prepend it to the script in
+     * the single multipart "script" field. Script.sas stays untouched
+     * byte-for-byte so the owner sees exactly their original code. */
+    %local sc ax;
+    %let sc = &b/script.sas;
+    %if %sysfunc(fileexist(&b/autoexec.sas)) %then %let ax = &b/autoexec.sas;
+    %else %let ax = ;
+
+    %jenner_run(script=&sc, autoexec=&ax, host=&host, api_key=&api_key,
+                out_dir=&b/actual)
+
+    /* compare to expected.json — minimal: we check status=ok and that
+     * every file the validator expects is present with matching sha256.
+     * A richer validator can live alongside expected.json as
+     * validate.sas (SAS-side) but isn't required.                       */
+    %local verdict msg;
+    %let verdict = unknown;
+    %let msg     = no expected.json;
+    %if %sysfunc(fileexist(&b/expected.json)) %then %do;
+      filename jcexp "&b/expected.json";
+      libname  jcexp JSON fileref=jcexp;
+
+      data _null_;
+        if 0 then set jcexp.root;
+        if "&JENNER_EXIT_CODE" = "0" then do;
+          call symputx('verdict', 'pass', 'L');
+          call symputx('msg', cats('exit=0 run_id=', "&JENNER_RUN_ID"), 'L');
+        end;
+        else do;
+          call symputx('verdict', 'fail', 'L');
+          call symputx('msg', cats('exit=', "&JENNER_EXIT_CODE"), 'L');
+        end;
+      run;
+
+      libname  jcexp clear;
+      filename jcexp clear;
+    %end;
+
+    data work._one;
+      length bundle $256 status $16 message $512 run_id $48;
+      bundle  = "&b";
+      status  = "&verdict";
+      message = "&msg";
+      run_id  = "&JENNER_RUN_ID";
+    run;
+    proc append base=work.jc_results data=work._one force; run;
+  %end;
+
+  /* write CSV report */
+  proc export data=work.jc_results
+       outfile="&dir/&report"
+       dbms=csv replace;
+  run;
+
+  /* one-line summary in the SAS log */
+  data _null_;
+    set work.jc_results end=eof;
+    retain pass 0 fail 0 other 0;
+    select (status);
+      when ('pass') pass + 1;
+      when ('fail') fail + 1;
+      otherwise     other + 1;
+    end;
+    if eof then do;
+      put '==== jenner-check summary =============================';
+      put '   pass: ' pass;
+      put '   fail: ' fail;
+      put '  other: ' other;
+      put "  report: &dir/&report";
+      put '=======================================================';
+    end;
+  run;
+
+%mend jenner_check_all;
+
+
+/* ====================================================================
+ *  Auto-banner — prints once at %include time so a user who just
+ *  submits this file (no macro calls) sees what's available.
+ *  Suppressed if %let JENNER_QUIET = 1; before %include.
+ *
+ *  Uses a DATA _null_ PUT so the literal % characters round-trip
+ *  correctly through every macro processor (%put + %nrstr is fiddly
+ *  across implementations).
+ * ==================================================================== */
+%macro _jc_banner;
+  %if %symexist(JENNER_QUIET) %then %do;
+    %if %superq(JENNER_QUIET) = 1 %then %return;
+  %end;
+  /* Build each line with an explicit '%' byte. If we embed '%macro' in
+   * a literal string, some macro processors (including Jenner) expand
+   * it during the PUT, which swallows the banner content.
+   * byte(37) = '%'. cats() concatenates without gluing in spaces. */
+  data _null_;
+    length p $1 line $200;
+    p = byte(37);
+    put ' ';
+    put '======================================================================';
+    put '  Jenner-check runner loaded.';
+    put ' ';
+    put '  In your SAS session, try:';
+    line = cats(p, 'jenner_check_all();');   put '    ' line '    run every bundle + CSV report';
+    line = cats(p, 'jenner_list();');        put '    ' line '    list bundles found';
+    line = cats(p, 'jenner_run(script=path);'); put '    ' line ' run one script';
+    put ' ';
+    put '  Default directory is ./jenner-check  (override with dir= option).';
+    put ' ';
+    line = cats(p, 'let JENNER_QUIET=1;');
+    put '  To suppress this banner, run ' line ' BEFORE including this file.';
+    put '======================================================================';
+    put ' ';
+  run;
+%mend _jc_banner;
+%_jc_banner
+
+options source2 notes;

--- a/jenner-check/run_jenner.sh
+++ b/jenner-check/run_jenner.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# run_jenner.sh - mac/linux runner for Jenner compatibility checks.
+#
+# Quick start:
+#   cd jenner-check/
+#   ./run_jenner.sh                  # lists bundles in the current dir
+#   ./run_jenner.sh t001_something   # run that one
+#   ./run_jenner.sh --all            # run every bundle in the current dir
+#
+# Usage:   ./run_jenner.sh [bundle-dir | script.sas | --all | --list] [response.json]
+#
+#   (no arg)     If the current directory has tNNN_* bundles, list them
+#                with a copy-paste command. Otherwise show this help.
+#
+#   --all        Run every tNNN_* bundle in the current directory in
+#                sequence, print a pass/fail summary.
+#
+#   --list, -l   List the bundles visible in the current directory and
+#                exit without running anything.
+#
+#   bundle-dir   A directory containing script.sas and (optionally)
+#                autoexec.sas. The two are concatenated (autoexec first,
+#                then a blank line, then script) and submitted together.
+#                This is the normal case.
+#
+#   script.sas   A single .sas file. Submitted as-is — no autoexec.
+#
+# The API response is written to <response.json> (or response.json in
+# the current directory if omitted) and the most useful fields are also
+# printed to stdout for a quick sanity check.
+#
+# Requires: bash 4+, curl. Both ship with every mainstream Linux distro
+# and macOS 12+. Windows: use run_jenner.bat (single-file mode) or WSL.
+#
+# IMPORTANT: execute this script, don't source it. Running with `. ./...`
+# or `source ./...` will short-circuit error handling and can close your
+# terminal if an error path fires.
+
+# --- refuse to be sourced ------------------------------------------------
+# `return` only works inside a sourced script. If we ARE sourced, print a
+# message and return 1 so we don't kill the parent shell with exit. If
+# we're running directly, (return 0) fails and we fall through.
+(return 0 2>/dev/null) && {
+  printf 'run_jenner.sh: execute this script, do not source it.\n  ./run_jenner.sh <bundle-dir-or-script.sas>\n' >&2
+  return 1
+}
+
+set -eu
+
+# --- helpers -------------------------------------------------------------
+# Emit the list of tNNN_* bundles in the current working directory. A
+# "bundle" is a directory matching t[0-9]*_* whose name contains a
+# script.sas file. Writes one path per line (no prefix); empty output
+# if nothing found.
+list_bundles_here() {
+  local d
+  for d in ./t[0-9]*_*/ ; do
+    [[ -d "$d" && -f "$d/script.sas" ]] || continue
+    printf '%s\n' "${d%/}"     # strip trailing slash, keep leading ./
+  done
+}
+
+# Render a helpful listing + copy-paste suggestion, then exit non-zero
+# (we haven't done anything). Used when the user runs with no args.
+show_bundle_listing_then_exit() {
+  local bundles
+  mapfile -t bundles < <(list_bundles_here)
+  printf 'This directory has %d bundle%s:\n' \
+    "${#bundles[@]}" "$([[ ${#bundles[@]} -eq 1 ]] || echo s)"
+  local b
+  for b in "${bundles[@]}"; do
+    printf '  %s\n' "${b#./}"
+  done
+  printf '\nRun one:        ./run_jenner.sh %s\n' "${bundles[0]#./}"
+  printf 'Run them all:   ./run_jenner.sh --all\n'
+  printf 'Just list:      ./run_jenner.sh --list\n'
+  exit 2
+}
+
+# Show the usage block when we have nothing better to offer.
+show_usage_then_exit() {
+  local status=${1:-2}
+  {
+    printf 'Usage: %s [bundle-dir | script.sas | --all | --list] [response.json]\n\n' "$(basename "$0")"
+    printf 'Examples:\n'
+    printf '  %s t001_my_bundle         # run one bundle\n' "$(basename "$0")"
+    printf '  %s --all                  # run every tNNN_* bundle in this dir\n' "$(basename "$0")"
+    printf '  %s path/to/script.sas     # run a single file, no autoexec\n' "$(basename "$0")"
+  } >&2
+  exit "$status"
+}
+
+# --- arg parsing ---------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  # No args: if the cwd contains bundles, list them; otherwise show help.
+  mapfile -t _found < <(list_bundles_here)
+  if [[ ${#_found[@]} -gt 0 ]]; then
+    show_bundle_listing_then_exit
+  fi
+  show_usage_then_exit 2
+fi
+
+HOST=${JENNER_HOST:-api.jenneranalytics.com}
+
+case "$1" in
+  -h|--help)
+    show_usage_then_exit 0
+    ;;
+  -l|--list)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)"
+      exit 0
+    fi
+    printf 'Bundles in %s:\n' "$(pwd)"
+    for b in "${_found[@]}"; do
+      printf '  %s\n' "${b#./}"
+    done
+    exit 0
+    ;;
+  --all)
+    mapfile -t _found < <(list_bundles_here)
+    if [[ ${#_found[@]} -eq 0 ]]; then
+      printf 'No tNNN_* bundles found in %s\n' "$(pwd)" >&2
+      exit 3
+    fi
+    _pass=0; _fail=0
+    for b in "${_found[@]}"; do
+      printf '\n── %s ──\n' "${b#./}"
+      if "$0" "$b" "${b#./}_response.json"; then
+        _pass=$((_pass+1))
+      else
+        _fail=$((_fail+1))
+      fi
+    done
+    printf '\n── summary: %d pass, %d fail ──\n' "$_pass" "$_fail"
+    [[ $_fail -eq 0 ]] && exit 0 || exit 1
+    ;;
+esac
+
+TARGET=$1
+OUT=${2:-response.json}
+
+# --- assemble the submission body ---------------------------------------
+# If TARGET is a directory, treat it as a bundle. If it's a file, submit
+# it directly.
+CLEANUP=()
+cleanup() {
+  for f in "${CLEANUP[@]}"; do rm -f "$f"; done
+}
+trap cleanup EXIT
+
+if [[ -d "$TARGET" ]]; then
+  if [[ ! -f "$TARGET/script.sas" ]]; then
+    printf 'error: %s is a directory but has no script.sas\n' "$TARGET" >&2
+    exit 3
+  fi
+  SUBMIT=$(mktemp -t jc_submit.XXXXXX.sas)
+  CLEANUP+=("$SUBMIT")
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    cat "$TARGET/autoexec.sas" > "$SUBMIT"
+    printf '\n' >> "$SUBMIT"
+  fi
+  cat "$TARGET/script.sas" >> "$SUBMIT"
+  printf 'Submitting bundle: %s\n' "$TARGET"
+  if [[ -f "$TARGET/autoexec.sas" ]]; then
+    printf '  autoexec.sas (%d bytes) + script.sas (%d bytes)\n' \
+      "$(wc -c < "$TARGET/autoexec.sas")" "$(wc -c < "$TARGET/script.sas")"
+  else
+    printf '  script.sas (%d bytes), no autoexec\n' "$(wc -c < "$TARGET/script.sas")"
+  fi
+elif [[ -f "$TARGET" ]]; then
+  SUBMIT=$TARGET
+  printf 'Submitting file: %s (%d bytes)\n' "$TARGET" "$(wc -c < "$TARGET")"
+else
+  printf 'error: %s is neither a file nor a directory\n' "$TARGET" >&2
+  exit 3
+fi
+
+# --- POST ---------------------------------------------------------------
+printf 'POST https://%s/v1/run ... ' "$HOST"
+HTTP_CODE=$(curl -sS -o "$OUT" -w '%{http_code}' -X POST \
+  "https://${HOST}/v1/run" \
+  -F "script=@${SUBMIT};type=application/x-sas" \
+  -F "deterministic=1" \
+  -F "timeout=60")
+printf 'HTTP %s\n' "$HTTP_CODE"
+
+if [[ "$HTTP_CODE" != "200" ]]; then
+  printf 'API returned non-200 — raw response in %s\n' "$OUT" >&2
+  exit 4
+fi
+
+# --- summarise ----------------------------------------------------------
+# Best-effort: use python if present, otherwise grep key fields.
+printf 'Response written to %s\n' "$OUT"
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUT" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+print(f"  status     : {r.get('status')}")
+print(f"  exit_code  : {r.get('exit_code')}")
+print(f"  duration_ms: {r.get('duration_ms')}")
+print(f"  run_id     : {r.get('run_id')}")
+print(f"  jenner_ver : {r.get('jenner_version')}")
+log = r.get('log', '')
+if log:
+    print('  log (first 10 lines):')
+    for line in log.splitlines()[:10]:
+        print(f'    {line}')
+PY
+else
+  printf '  (install python3 for a pretty summary; raw JSON in %s)\n' "$OUT"
+fi

--- a/jenner-check/t001_acs_pums_merge/autoexec.sas
+++ b/jenner-check/t001_acs_pums_merge/autoexec.sas
@@ -1,0 +1,68 @@
+options obs=100;
+
+/* --------------------------------------------------------------------
+   Bundle setup for Acs_pums_2005 (population x housing merge).
+
+   The library program reads zipped Census PUMS housing and population
+   files from per-state libraries under &_dcdata_path, then merges them
+   into the _WAS (Washington region) and _COMP (comparison cities)
+   output data sets, applying the $pum0fpl PUMA-to-place format built by
+   Puma_to_city_formats.sas.
+
+   This setup supplies:
+     - the $pum0fpl format (a small CNTLIN drawn from the program's own
+       comparison-city place codes),
+     - small population and housing work data sets shaped like the
+       psam_p / psam_h PUMS extracts the merge consumes.
+   The merge DATA step itself is the program's own code, unchanged.
+   -------------------------------------------------------------------- */
+
+%let year = 2005;
+
+/* $pum0fpl: unique PUMA (statecd||z5 puma) -> unique FIPS place code */
+data _pum0fpl;
+  retain fmtname '$pum0fpl' type 'C';
+  input start $ label $;
+  datalines;
+1100102 1150000
+2401002 2404000
+2503301 2507000
+2603201 2622000
+3901901 3916000
+4204101 4260000
+5505301 5553000
+;
+run;
+
+proc format cntlin=_pum0fpl;
+run;
+
+/* Population extract (psam_p*) shape: state, serial, person, puma, weight, esr, agep */
+data population;
+  length Userialno $ 10;
+  input st $ serialno sporder puma rt $ pwgtp esr $ agep;
+  Userialno = put( 1 * st, z2. ) || put( 1 * serialno, z8. );
+  datalines;
+11 100 1 102 P 90 1 35
+11 100 2 102 P 90 6 5
+24 200 1 1002 P 60 2 40
+26 300 1 3201 P 75 1 52
+99 400 1 9901 P 30 1 41
+;
+run;
+
+/* Housing extract (psam_h*) shape: state, serial, puma, weight, adjust */
+data housing;
+  length Userialno $ 10;
+  input st $ serialno puma rt $ wgtp adjust;
+  Userialno = put( 1 * st, z2. ) || put( 1 * serialno, z8. );
+  datalines;
+11 100 102 H 90 1000000
+24 200 1002 H 60 1000000
+26 300 3201 H 75 1000000
+99 400 9901 H 30 1000000
+;
+run;
+
+proc sort data=population; by Userialno sporder; run;
+proc sort data=housing;    by Userialno; run;

--- a/jenner-check/t001_acs_pums_merge/expected.json
+++ b/jenner-check/t001_acs_pums_merge/expected.json
@@ -1,0 +1,13 @@
+{
+  "_captured_at": "2026-06-17T19:30:10+07:00",
+  "_captured_run_id": "r_019ed58f53d176528331ed6d3addee7f",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "Wrote Acs_pums_2005_was (3 rows, 13 columns).",
+    "Wrote Acs_pums_2005_comp (4 rows, 13 columns).",
+    "PROC FREQ"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t001_acs_pums_merge/expected/files.md
+++ b/jenner-check/t001_acs_pums_merge/expected/files.md
@@ -1,0 +1,22 @@
+These URLs point to artifacts from one specific run (run_id below) and expire when that run is reaped. Re-running the bundle regenerates them.
+
+run_id: r_019ed58f53d176528331ed6d3addee7f
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 975 | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/files/listing.txt?token=207035d106d24f9f8e52c454254b4e3f |
+| ods_output/freq_uplacefp.png | image/png | 16154 | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/files/ods_output/freq_uplacefp.png?token=207035d106d24f9f8e52c454254b4e3f |
+| ods_output/freq_uplacefp.svg | image/svg+xml | 9585 | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/files/ods_output/freq_uplacefp.svg?token=207035d106d24f9f8e52c454254b4e3f |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| _pum0fpl | 7 | ['fmtname', 'type', 'start', 'label'] | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/datasets/_pum0fpl?token=207035d106d24f9f8e52c454254b4e3f |
+| acs_pums_2005_comp | 4 | ['Upuma', 'Uplacefp', 'Year', 'Userialno', 'sporder', 'pwgtp', 'esr', 'agep', 'Statecd', 'serialno', 'puma', 'wgtp', 'adjust'] | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/datasets/acs_pums_2005_comp?token=207035d106d24f9f8e52c454254b4e3f |
+| acs_pums_2005_was | 3 | ['Upuma', 'Uplacefp', 'Year', 'Userialno', 'sporder', 'pwgtp', 'esr', 'agep', 'Statecd', 'serialno', 'puma', 'wgtp', 'adjust'] | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/datasets/acs_pums_2005_was?token=207035d106d24f9f8e52c454254b4e3f |
+| housing | 4 | ['Userialno', 'st', 'serialno', 'puma', 'rt', 'wgtp', 'adjust'] | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/datasets/housing?token=207035d106d24f9f8e52c454254b4e3f |
+| population | 5 | ['Userialno', 'st', 'serialno', 'sporder', 'puma', 'rt', 'pwgtp', 'esr', 'agep'] | https://api.jenneranalytics.com/v1/run/r_019ed58f53d176528331ed6d3addee7f/datasets/population?token=207035d106d24f9f8e52c454254b4e3f |
+

--- a/jenner-check/t001_acs_pums_merge/expected/log.txt
+++ b/jenner-check/t001_acs_pums_merge/expected/log.txt
@@ -1,0 +1,64 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA _pum0fpl
+
+NOTE: Processing inline DATALINES (7 lines)
+
+NOTE: Read 7 rows from DATALINES.
+NOTE: Wrote _pum0fpl (7 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC FORMAT library=WORK
+
+NOTE: CNTLIN: Loaded 7 format entries from _pum0fpl
+NOTE: DATA population
+
+NOTE: Processing inline DATALINES (5 lines)
+
+NOTE: Read 5 rows from DATALINES.
+NOTE: Wrote population (5 rows, 9 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA housing
+
+NOTE: Processing inline DATALINES (4 lines)
+
+NOTE: Read 4 rows from DATALINES.
+NOTE: Wrote housing (4 rows, 7 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC SORT data=population
+
+NOTE: Unlicensed mode - input limited to 100 observations.
+NOTE: Read 5 rows from population.
+NOTE: Wrote population (5 rows, 9 columns).
+NOTE: PROC SORT statement used.
+NOTE: PROC SORT data=housing
+
+NOTE: Unlicensed mode - input limited to 100 observations.
+NOTE: Read 4 rows from housing.
+NOTE: Wrote housing (4 rows, 7 columns).
+NOTE: PROC SORT statement used.
+NOTE: DATA Acs_pums_2005_was Acs_pums_2005_comp
+
+NOTE: Multi-output DATA step splits stream into: Acs_pums_2005_was Acs_pums_2005_comp
+NOTE: Stream 1 processed 5 rows, max BY-group size: 2 (O(1) memory verified)
+NOTE: Stream 2 processed 4 rows, max BY-group size: 1 (O(1) memory verified)
+
+NOTE: Wrote Acs_pums_2005_was (3 rows, 13 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+
+NOTE: Wrote Acs_pums_2005_comp (4 rows, 13 columns).
+NOTE: PROC PRINT data=Acs_pums_2005_was
+
+NOTE: PROC PRINT completed: 3 observations printed, 6 variables
+NOTE: PROC FREQ
+NOTE: ODS plot written: freq_uplacefp.spec.json
+NOTE: PROC FREQ statement used.

--- a/jenner-check/t001_acs_pums_merge/expected/output.txt
+++ b/jenner-check/t001_acs_pums_merge/expected/output.txt
@@ -1,0 +1,17 @@
+                                    ACS PUMS 2005 - Washington region (DC/MD/VA/WV)                                     
+
+  Obs  Year   Userialno  Statecd    Upuma  Uplacefp  agep
+    1  2005  1100000100  11       1100102  1150000     35
+    2  2005  1100000100  11       1100102  1150000      5
+    3  2005  2400000200  24       2401002  2404000     40
+
+                                      ACS PUMS 2005 - comparison-city place codes                                       
+
+                                                   The FREQ Procedure
+
+                                                              Cumulative    Cumulative
+Unique FIPS place code (ssppppp)    Frequency    Percent     Frequency      Percent
+-----------------------------------------------------------------------------------------
+1150000                                     2     50.00            2        50.00
+2404000                                     1     25.00            3        75.00
+2622000                                     1     25.00            4       100.00

--- a/jenner-check/t001_acs_pums_merge/meta.json
+++ b/jenner-check/t001_acs_pums_merge/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t001_acs_pums_merge",
+  "source_file": "Prog/Acs_pums_2005.sas",
+  "source_blob_sha": "42d15d3cea55b2e1c12f6b4ba3e838451acb5941",
+  "source_commit": "1921d40523961ca3d6d0bfa2b8df87784713c8cc",
+  "tier": "real_data_substituted",
+  "notes": "Exercises the program's PUMS population x housing MERGE: unique-key (z2 state || z8 serial) and unique-PUMA (state || z5 puma) construction, $pum0fpl place lookup, region (DC/MD/VA/WV) and comparison-city dual OUTPUT split, rename/label. population and housing are small inline psam_p/psam_h-shaped work sets standing in for the zipped Census libraries; output libref is WORK (ACS library is external); the framework non-match diagnostic is written as a plain PUT."
+}

--- a/jenner-check/t001_acs_pums_merge/script.sas
+++ b/jenner-check/t001_acs_pums_merge/script.sas
@@ -1,0 +1,74 @@
+/**************************************************************************
+ Bundle:   t001_acs_pums_merge
+ Source:   Prog/Acs_pums_2005.sas (NeighborhoodInfoDC/ACS)
+ Author:   P. Tatian, bundled for Jenner compatibility check
+
+ Merge the PUMS population and housing extracts into the Washington
+ region (_was) and comparison-city (_comp) data sets. The merge logic,
+ unique-key and unique-PUMA construction, the $pum0fpl place lookup, the
+ region/comparison-city output split, and the rename/label/format
+ statements are the program's own. The output libref is WORK here (the
+ ACS library is external) and the framework non-match diagnostic is
+ written here as a plain PUT.
+**************************************************************************/
+
+data
+  Acs_pums_&year._was
+  Acs_pums_&year._comp ;
+
+  retain Year &year;
+
+  merge
+    population (in=inP drop=rt serialno puma st)
+    housing (in=inH drop=rt);
+  by Userialno;
+
+  if not( inH ) or ( not( inP ) and np > 0 ) then do;
+    put "WARNING: Nonmatching population and housing records: "
+        Userialno= st= serialno= sporder= inP= inH=;
+  end;
+
+  length Upuma Uplacefp $ 7;
+
+  upuma = st || put( 1 * puma, z5. );
+
+  uplacefp = put( upuma, $pum0fpl. );
+
+  ** Washington region states (DC/MD/VA/WV) **;
+
+  if st in ( '11', '24', '51', '54' ) then output Acs_pums_&year._was;
+
+  ** Comparison cities **;
+
+  if uplacefp in (
+    "1150000",  /** Washington, DC **/
+    "2255000",  /** New Orleans **/
+    "2404000",  /** Baltimore **/
+    "2507000",  /** Boston **/
+    "2622000",  /** Detroit **/
+    "2965000",  /** St. Louis **/
+    "3916000",  /** Cleveland **/
+    "4260000",  /** Philadelphia **/
+    "5553000"   /** Milwaukee **/
+    )
+  then output Acs_pums_&year._comp;
+
+  rename st=Statecd;
+
+  label
+    userialno = 'Unique serial number'
+    year = 'Year of survey'
+    upuma = 'Unique PUMA code (ssppppp)'
+    uplacefp = 'Unique FIPS place code (ssppppp)';
+
+run;
+
+proc print data=Acs_pums_&year._was;
+  var year userialno statecd upuma uplacefp agep;
+  title "ACS PUMS &year - Washington region (DC/MD/VA/WV)";
+run;
+
+proc freq data=Acs_pums_&year._comp;
+  tables uplacefp;
+  title "ACS PUMS &year - comparison-city place codes";
+run;

--- a/jenner-check/t002_acs_children_hh/autoexec.sas
+++ b/jenner-check/t002_acs_children_hh/autoexec.sas
@@ -1,0 +1,32 @@
+options obs=100;
+
+/* --------------------------------------------------------------------
+   Bundle setup for Acs_comp_table_dat (household accumulator).
+
+   The library program reads the comparison-city PUMS extract
+   Acs.Acs_pums_2005_comp (built by Acs_pums_2005.sas) and rolls
+   person records up to households for children under 3.
+
+   This setup supplies a small Acs_pums_2005_comp work data set with the
+   person-level columns the accumulator reads (year, userialno,
+   uplacefp, weights, age, employment, earnings, etc.), shaped like the
+   comparison-city extract. The accumulator DATA step is the program's
+   own code; the only adaptation is that the output keep= lists name the
+   household-summary variables explicitly rather than by num_:/hh_:/
+   hhh_:/is_: name prefixes.
+   -------------------------------------------------------------------- */
+
+data Acs_pums_2005_comp;
+  length userialno $ 10 uplacefp $ 7 esr $ 1 rel $ 2 cit $ 1;
+  input year userialno $ uplacefp $ pwgtp wgtp npp hht $ agep esr $ wkhp
+        rel $ cit $ schl pernp pincp pap ssip;
+  datalines;
+2005 1100000100 1150000 90 90 1 1 35 1 40 01 1 13 52000 55000 0 0
+2005 1100000100 1150000 90 90 1 1 33 1 38 01 1 12 28000 30000 0 0
+2005 1100000100 1150000 90 90 1 1 2 0 0 11 1 1 0 0 0 0
+2005 2400000200 2404000 60 60 1 3 41 2 36 01 4 9 31000 33000 0 1200
+2005 2400000200 2404000 60 60 1 3 1 0 0 02 4 1 0 0 0 0
+2005 2600000300 2622000 75 75 1 1 52 1 45 01 1 16 70000 72000 0 0
+2005 2600000300 2622000 75 75 1 1 1 0 0 02 1 1 0 0 0 0
+;
+run;

--- a/jenner-check/t002_acs_children_hh/expected.json
+++ b/jenner-check/t002_acs_children_hh/expected.json
@@ -1,0 +1,13 @@
+{
+  "_captured_at": "2026-06-17T19:39:54+07:00",
+  "_captured_run_id": "r_019ed5982f307502970f7807812d9080",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "Read 7 rows from Acs_pums_2005_comp.",
+    "Wrote Acs_comp_table",
+    "PROC FREQ"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR", "panicked"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t002_acs_children_hh/expected/files.md
+++ b/jenner-check/t002_acs_children_hh/expected/files.md
@@ -1,0 +1,25 @@
+These URLs point to artifacts from one specific run (run_id below) and expire when that run is reaped. Re-running the bundle regenerates them.
+
+run_id: r_019ed5982f307502970f7807812d9080
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 2040 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/listing.txt?token=3293ba3abc954895995b0ff9ab440ce5 |
+| ods_output/freq_mosaic_comp_city_hht.png | image/png | 15836 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/ods_output/freq_mosaic_comp_city_hht.png?token=3293ba3abc954895995b0ff9ab440ce5 |
+| ods_output/freq_mosaic_comp_city_hht.svg | image/svg+xml | 6997 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/ods_output/freq_mosaic_comp_city_hht.svg?token=3293ba3abc954895995b0ff9ab440ce5 |
+| ods_output/freq_mosaic_hh_has_earn_hh_has_ssi.png | image/png | 18968 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/ods_output/freq_mosaic_hh_has_earn_hh_has_ssi.png?token=3293ba3abc954895995b0ff9ab440ce5 |
+| ods_output/freq_mosaic_hh_has_earn_hh_has_ssi.svg | image/svg+xml | 5645 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/ods_output/freq_mosaic_hh_has_earn_hh_has_ssi.svg?token=3293ba3abc954895995b0ff9ab440ce5 |
+| ods_output/freq_mosaic_hht_hh_has_earn.png | image/png | 16445 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/ods_output/freq_mosaic_hht_hh_has_earn.png?token=3293ba3abc954895995b0ff9ab440ce5 |
+| ods_output/freq_mosaic_hht_hh_has_earn.svg | image/svg+xml | 5485 | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/files/ods_output/freq_mosaic_hht_hh_has_earn.svg?token=3293ba3abc954895995b0ff9ab440ce5 |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| acs_comp_table | 3 | ['num_persons', 'num_children', 'num_children_0_2', 'num_adults', 'num_work_adults', 'num_work_ft_adults', 'hh_earnings', 'hh_income', 'hh_pub_assist', 'hh_ssi', 'hhh_age', 'hhh_educ', 'hhh_citizen', 'userialno', 'uplacefp', 'year', 'wgtp', 'npp', 'hht', 'comp_city', 'num_hhs', 'hh_gp', 'hh_has_earn', 'hh_has_pub_assist', 'hh_has_ssi', 'rel', 'cit', 'pwgtp', 'agep', 'count', 'is_foster'] | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/datasets/acs_comp_table?token=3293ba3abc954895995b0ff9ab440ce5 |
+| acs_pums_2005_comp | 7 | ['userialno', 'uplacefp', 'esr', 'rel', 'cit', 'year', 'pwgtp', 'wgtp', 'npp', 'hht', 'agep', 'wkhp', 'schl', 'pernp', 'pincp', 'pap', 'ssip'] | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/datasets/acs_pums_2005_comp?token=3293ba3abc954895995b0ff9ab440ce5 |
+| hh | 3 | ['num_persons', 'num_children', 'num_children_0_2', 'num_adults', 'num_work_adults', 'num_work_ft_adults', 'hh_earnings', 'hh_income', 'hh_pub_assist', 'hh_ssi', 'hhh_age', 'hhh_educ', 'hhh_citizen', 'userialno', 'uplacefp', 'year', 'wgtp', 'npp', 'hht', 'comp_city', 'num_hhs', 'hh_gp', 'hh_has_earn', 'hh_has_pub_assist', 'hh_has_ssi'] | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/datasets/hh?token=3293ba3abc954895995b0ff9ab440ce5 |
+| pers | 3 | ['userialno', 'rel', 'cit', 'year', 'pwgtp', 'agep', 'count', 'is_foster'] | https://api.jenneranalytics.com/v1/run/r_019ed5982f307502970f7807812d9080/datasets/pers?token=3293ba3abc954895995b0ff9ab440ce5 |
+

--- a/jenner-check/t002_acs_children_hh/expected/log.txt
+++ b/jenner-check/t002_acs_children_hh/expected/log.txt
@@ -1,0 +1,40 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA Acs_pums_2005_comp
+
+NOTE: Processing inline DATALINES (7 lines)
+
+NOTE: Read 7 rows from DATALINES.
+NOTE: Wrote Acs_pums_2005_comp (7 rows, 17 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA pers hh
+
+NOTE: Multi-output DATA step splits stream into: pers hh
+
+NOTE: Read 7 rows from Acs_pums_2005_comp.
+NOTE: Wrote pers (3 rows, 38 columns).
+NOTE: Wrote hh (3 rows, 38 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: DATA Acs_comp_table
+
+NOTE: Stream 1 processed 3 rows, max BY-group size: 1 (O(1) memory verified)
+NOTE: Stream 2 processed 3 rows, max BY-group size: 1 (O(1) memory verified)
+
+NOTE: Wrote Acs_comp_table (3 rows, 31 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=hh
+
+NOTE: PROC PRINT completed: 3 observations printed, 9 variables
+NOTE: PROC FREQ
+NOTE: ODS plot written: freq_mosaic_comp_city_hht.spec.json
+NOTE: ODS plot written: freq_mosaic_hht_hh_has_earn.spec.json
+NOTE: ODS plot written: freq_mosaic_hh_has_earn_hh_has_ssi.spec.json
+NOTE: PROC FREQ statement used.

--- a/jenner-check/t002_acs_children_hh/expected/output.txt
+++ b/jenner-check/t002_acs_children_hh/expected/output.txt
@@ -1,0 +1,67 @@
+                                  Households with children under 3, by comparison city                                  
+
+ userialno  comp_city  num_persons  num_children  num_adults  num_work_adults  num_work_ft_adults  hh_income  hh_has_earn
+1100000100          1            3             1           2                2                   2      85000          100
+2400000200          2            2             1           1                1                   1      33000          100
+2600000300          4            2             1           1                1                   1      72000          100
+
+                                          Comparison-city household indicators                                          
+
+                                                   The FREQ Procedure
+
+Controlling for comp_city=1
+
+Table of hht by hh_has_earn
+
+hht |       100 |      Total
+----+-----------+-----------
+1   |         1 |          1
+    |    100.00 |     100.00
+    |    100.00 |     100.00
+    |    100.00 |     100.00
+----+-----------+-----------
+3   |         0 |          0
+    |      0.00 |       0.00
+    |      0.00 |     100.00
+    |      0.00 |       0.00
+----+-----------+-----------
+Total |         1 |          1
+
+
+Controlling for comp_city=2
+
+Table of hht by hh_has_earn
+
+hht |       100 |      Total
+----+-----------+-----------
+1   |         0 |          0
+    |      0.00 |       0.00
+    |      0.00 |     100.00
+    |      0.00 |       0.00
+----+-----------+-----------
+3   |         1 |          1
+    |    100.00 |     100.00
+    |    100.00 |     100.00
+    |    100.00 |     100.00
+----+-----------+-----------
+Total |         1 |          1
+
+
+Controlling for comp_city=4
+
+Table of hht by hh_has_earn
+
+hht |       100 |      Total
+----+-----------+-----------
+1   |         1 |          1
+    |    100.00 |     100.00
+    |    100.00 |     100.00
+    |    100.00 |     100.00
+----+-----------+-----------
+3   |         0 |          0
+    |      0.00 |       0.00
+    |      0.00 |     100.00
+    |      0.00 |       0.00
+----+-----------+-----------
+Total |         1 |          1
+

--- a/jenner-check/t002_acs_children_hh/meta.json
+++ b/jenner-check/t002_acs_children_hh/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t002_acs_children_hh",
+  "source_file": "Prog/Acs_comp_table_dat.sas",
+  "source_blob_sha": "0d0c3ca0a5b78995987d142eb741a3f0519b47fa",
+  "source_commit": "1921d40523961ca3d6d0bfa2b8df87784713c8cc",
+  "tier": "real_data_substituted",
+  "notes": "Exercises the program's household accumulator for children under 3: WHERE comparison-city filter, SELECT/WHEN comp_city assignment, FIRST./LAST. BY-group accumulation with RETAIN, person/household dual OUTPUT, and household-level indicators. Acs_pums_2005_comp is a small inline comparison-city extract; input/output librefs are WORK. The output keep= lists name the household-summary variables explicitly rather than by num_:/hh_:/hhh_:/is_: name prefixes."
+}

--- a/jenner-check/t002_acs_children_hh/script.sas
+++ b/jenner-check/t002_acs_children_hh/script.sas
@@ -1,0 +1,140 @@
+/**************************************************************************
+ Bundle:   t002_acs_children_hh
+ Source:   Prog/Acs_comp_table_dat.sas (NeighborhoodInfoDC/ACS)
+ Author:   P. Tatian, bundled for Jenner compatibility check
+
+ Roll PUMS person records up to households for children under age 3 in
+ the comparison cities. The comparison-city assignment (SELECT/WHEN),
+ the BY-group accumulation (FIRST./LAST., RETAIN), the person/household
+ dual OUTPUT, and the household-level summary indicators are the
+ program's own code. Only the input/output librefs are WORK here.
+**************************************************************************/
+
+%let maxobs = 100000000;
+
+data
+  pers
+    (compress=no
+     keep=year userialno pwgtp count agep esp rel povpip cit is_foster )
+  hh
+    (compress=no
+     keep=year userialno uplacefp wgtp comp_city hht npp
+          num_persons num_children num_children_0_2 num_adults
+          num_work_adults num_work_ft_adults num_hhs
+          hh_earnings hh_income hh_pub_assist hh_ssi hh_gp
+          hh_has_earn hh_has_pub_assist hh_has_ssi
+          hhh_age hhh_educ hhh_citizen )
+  ;
+
+  set
+    Acs_pums_2005_comp (obs=&maxobs)
+  ;
+  by year userialno;
+
+  where uplacefp in (
+    "1150000",  /** Washington, DC **/
+    /**"2255000",  /** New Orleans **/
+    "2404000",  /** Baltimore **/
+    "2507000",  /** Boston **/
+    "2622000",  /** Detroit **/
+    /**"2965000",  /** St. Louis **/
+    "3916000",  /** Cleveland **/
+    "4260000",  /** Philadelphia **/
+    "5553000"   /** Milwaukee **/
+    );
+
+  select ( uplacefp );
+    when ( "1150000" ) comp_city = 1;  /** Washington, DC **/
+    when ( "2404000" ) comp_city = 2;  /** Baltimore **/
+    when ( "2507000" ) comp_city = 3;  /** Boston **/
+    when ( "2622000" ) comp_city = 4;  /** Detroit **/
+    when ( "3916000" ) comp_city = 5;  /** Cleveland **/
+    when ( "4260000" ) comp_city = 6;  /** Philadelphia **/
+    when ( "5553000" ) comp_city = 7;  /** Milwaukee **/
+  end;
+
+  retain num_persons num_children num_children_0_2
+         num_adults num_work_adults num_work_ft_adults
+         hh_earnings hh_income hh_pub_assist hh_ssi
+         hhh_age hhh_educ hhh_citizen;
+
+  if first.userialno then do;
+    num_persons = 0;
+    num_children = 0;
+    num_children_0_2 = 0;
+    num_adults = 0;
+    num_work_adults = 0;
+    num_work_ft_adults = 0;
+    hh_earnings = 0;
+    hh_income = 0;
+    hh_ssi = 0;
+    hh_pub_assist = 0;
+    hhh_age = agep;
+    hhh_educ = 1 * schl;
+    hhh_citizen = cit;
+  end;
+
+  count = 1;
+
+  num_persons + 1;
+
+  if 0 <= agep < 18 then num_children + 1;
+  else do;
+    num_adults + 1;
+    if esr in ( '1', '2', '4', '5' ) then do;
+      num_work_adults + 1;
+      if wkhp >= 35 then num_work_ft_adults + 1;
+    end;
+  end;
+
+  if 0 <= agep < 3 then do;
+    num_children_0_2 + 1;
+    if rel = '11' then is_foster = 1;
+    else is_foster = 0;
+  end;
+
+  hh_earnings = sum( hh_earnings, pernp );
+  hh_income = sum( hh_income, pincp );
+  hh_pub_assist = sum( hh_pub_assist, pap );
+  hh_ssi = sum( hh_ssi, ssip );
+
+  if 0 <= agep < 3 then output pers;
+
+  if last.userialno and num_children_0_2 > 0 then do;
+
+    num_hhs = 1 / num_children_0_2;
+
+    hh_gp = 100 * npp;
+
+    if hh_earnings > 0 then hh_has_earn = 100;
+    else hh_has_earn = 0;
+
+    if hh_pub_assist > 0 then hh_has_pub_assist = 100;
+    else hh_has_pub_assist = 0;
+
+    if hh_ssi > 0 then hh_has_ssi = 100;
+    else hh_has_ssi = 0;
+
+    output hh;
+
+  end;
+
+run;
+
+data Acs_comp_table;
+
+  merge hh pers;
+  by year userialno;
+
+run;
+
+proc print data=hh noobs;
+  var userialno comp_city num_persons num_children num_adults
+      num_work_adults num_work_ft_adults hh_income hh_has_earn;
+  title 'Households with children under 3, by comparison city';
+run;
+
+proc freq data=Acs_comp_table;
+  tables comp_city * ( hht hh_has_earn hh_has_ssi ) / missing list;
+  title 'Comparison-city household indicators';
+run;

--- a/jenner-check/t003_acs_comp_table/autoexec.sas
+++ b/jenner-check/t003_acs_comp_table/autoexec.sas
@@ -1,0 +1,34 @@
+options obs=100;
+
+/* --------------------------------------------------------------------
+   Bundle setup for Acs_comp_table (PROC TABULATE report).
+
+   The library program builds an RTF table from Acs.Acs_comp_table (the
+   household-level file produced by Acs_comp_table_dat.sas), classifying
+   children under 3 by comparison city and household characteristics.
+
+   This setup supplies a small Acs_comp_table work data set with the
+   class/analysis columns the report consumes, and a no-op %fdate macro
+   (the DCData macro that sets &fdate for the footnote). The PROC FORMAT
+   value definitions and the PROC TABULATE statement are the program's
+   own code, unchanged; output is the default listing rather than RTF.
+   -------------------------------------------------------------------- */
+
+%macro fdate;
+%mend fdate;
+%let fdate = ;
+
+data Acs_comp_table;
+  length hht $ 1 hhh_citizen $ 1;
+  input comp_city hht $ hhh_age hhh_educ hhh_citizen $ povpip wgtp
+        count num_hhs num_persons num_children num_adults
+        hh_income hh_earnings hh_has_earn hh_has_pub_assist hh_has_ssi
+        num_work_adults num_work_ft_adults;
+  datalines;
+1 1 33 13 1 175 90 1 1.0 3 1 2 85000 82000 100 0 0 2 2
+1 3 41 9 4 150 60 1 1.0 2 1 1 33000 31000 100 0 100 1 1
+2 1 52 16 1 250 75 1 1.0 2 1 1 72000 70000 100 0 0 1 1
+2 1 29 10 1 90 80 1 1.0 4 2 2 41000 39000 100 100 0 2 1
+3 3 38 12 5 60 70 1 1.0 3 2 1 22000 0 0 100 0 1 0
+;
+run;

--- a/jenner-check/t003_acs_comp_table/expected.json
+++ b/jenner-check/t003_acs_comp_table/expected.json
@@ -1,0 +1,12 @@
+{
+  "_captured_at": "2026-06-17T19:41:07+07:00",
+  "_captured_run_id": "r_019ed59960ca7162ac0ca9d6d671280c",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "PROC FORMAT library=WORK",
+    "PROC TABULATE"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR", "panicked"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t003_acs_comp_table/expected/files.md
+++ b/jenner-check/t003_acs_comp_table/expected/files.md
@@ -1,0 +1,16 @@
+These URLs point to artifacts from one specific run (run_id below) and expire when that run is reaped. Re-running the bundle regenerates them.
+
+run_id: r_019ed59960ca7162ac0ca9d6d671280c
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 3978 | https://api.jenneranalytics.com/v1/run/r_019ed59960ca7162ac0ca9d6d671280c/files/listing.txt?token=90917ddabfd346bcb5b9d82b9105d368 |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| acs_comp_table | 5 | ['hht', 'hhh_citizen', 'comp_city', 'hhh_age', 'hhh_educ', 'povpip', 'wgtp', 'count', 'num_hhs', 'num_persons', 'num_children', 'num_adults', 'hh_income', 'hh_earnings', 'hh_has_earn', 'hh_has_pub_assist', 'hh_has_ssi', 'num_work_adults', 'num_work_ft_adults'] | https://api.jenneranalytics.com/v1/run/r_019ed59960ca7162ac0ca9d6d671280c/datasets/acs_comp_table?token=90917ddabfd346bcb5b9d82b9105d368 |
+

--- a/jenner-check/t003_acs_comp_table/expected/log.txt
+++ b/jenner-check/t003_acs_comp_table/expected/log.txt
@@ -1,0 +1,23 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA Acs_comp_table
+
+NOTE: Processing inline DATALINES (5 lines)
+
+NOTE: Read 5 rows from DATALINES.
+NOTE: Wrote Acs_comp_table (5 rows, 19 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC FORMAT library=WORK
+
+NOTE: FORMAT city defined (7 ranges).
+NOTE: FORMAT $hht defined (3 ranges).
+NOTE: FORMAT agep defined (2 ranges).
+NOTE: FORMAT educ defined (5 ranges).
+NOTE: FORMAT $cit defined (5 ranges).
+NOTE: FORMAT pov defined (5 ranges).
+NOTE: Option MISSING changed to -.
+NOTE: PROC TABULATE

--- a/jenner-check/t003_acs_comp_table/expected/output.txt
+++ b/jenner-check/t003_acs_comp_table/expected/output.txt
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------------------------------
+|                                                        | Washington, DC | Baltimore  |   Boston   |
+|--------------------------------------------------------+----------------+------------+------------|
+|                                      |        |        |           150.0|       155.0|        70.0|
+|Number of HHs w/children < 3 years old|        |        |           150.0|       155.0|        70.0|
+|Avg. HH size                          |        |        |             2.6|         3.0|         3.0|
+|Avg. num. adults/HH                   |        |        |             1.6|         1.5|         1.0|
+|% Children by household type          |        |        |                |            |            |
+|Married-couple family                 |        |        |            50.0|       100.0|         0.0|
+|Female-headed family                  |        |        |            50.0|         0.0|       100.0|
+|% Children by age of HH head          |        |        |                |            |            |
+|Under 65                              |        |        |             0.0|        50.0|         0.0|
+|                                      |        |        |            50.0|         0.0|         0.0|
+|                                      |        |        |             0.0|         0.0|       100.0|
+|                                      |        |        |            50.0|         0.0|         0.0|
+|                                      |        |        |             0.0|        50.0|         0.0|
+|% Children by education of HH head    |        |        |                |            |            |
+|HS graduate                           |        |        |            50.0|         0.0|         0.0|
+|Some college                          |        |        |             0.0|        50.0|       100.0|
+|Bachelors degree                      |        |        |            50.0|         0.0|         0.0|
+|Advanced degree                       |        |        |             0.0|        50.0|         0.0|
+|% Children by citizenship of HH head  |        |        |                |            |            |
+|Native born citizen                   |        |        |            50.0|       100.0|         0.0|
+|Naturalized citizen                   |        |        |            50.0|         0.0|         0.0|
+|Not a US citizen                      |        |        |             0.0|         0.0|       100.0|
+|Avg. num. working adults/HH           |        |        |             1.6|         1.5|         1.0|
+|Avg. num. FT working adults/HH        |        |        |             1.6|         1.0|         0.0|
+|Median HH income ($)                  |        |        |        59,000.0|    56,500.0|    22,000.0|
+|Median HH earnings ($)                |        |        |        56,500.0|    54,500.0|         0.0|
+|% HHs w/earnings                      |        |        |           100.0|       100.0|         0.0|
+|% HHs w/pub. assistance               |        |        |             0.0|        51.6|       100.0|
+|% HHs w/SSI                           |        |        |            40.0|         0.0|         0.0|
+|% Children by poverty status          |        |        |                |            |            |
+|100-199% poverty                      |        |        |            50.0|         0.0|         0.0|
+|                                      |        |        |            50.0|         0.0|         0.0|
+|200% poverty or higher                |        |        |             0.0|        50.0|         0.0|
+|50-99% poverty                        |        |        |             0.0|         0.0|       100.0|
+|                                      |        |        |             0.0|        50.0|         0.0|
+-----------------------------------------------------------------------------------------------------
+

--- a/jenner-check/t003_acs_comp_table/meta.json
+++ b/jenner-check/t003_acs_comp_table/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t003_acs_comp_table",
+  "source_file": "Prog/Acs_comp_table.sas",
+  "source_blob_sha": "cd996a51c6e627e38bae96d48f5e7492fe0d23e2",
+  "source_commit": "1921d40523961ca3d6d0bfa2b8df87784713c8cc",
+  "tier": "real_data_substituted",
+  "notes": "Exercises the program's comparison-city report: PROC FORMAT value/picture definitions (city, $hht, agep, educ, $cit, pov) and the PROC TABULATE class/var/weight/table specification (sum, mean, median, colpctsum) classifying children under 3 by city, household type, head age/education/citizenship, and poverty. Acs_comp_table is a small inline household-level work set; %fdate is a no-op; output is the default listing rather than the RTF destination."
+}

--- a/jenner-check/t003_acs_comp_table/script.sas
+++ b/jenner-check/t003_acs_comp_table/script.sas
@@ -1,0 +1,88 @@
+/**************************************************************************
+ Bundle:   t003_acs_comp_table
+ Source:   Prog/Acs_comp_table.sas (NeighborhoodInfoDC/ACS)
+ Author:   P. Tatian, bundled for Jenner compatibility check
+
+ Tabulate characteristics of children under age 3 and their households
+ for Washington, D.C. and comparison cities. The PROC FORMAT value
+ definitions and the PROC TABULATE class/var/weight/table specification
+ are the program's own code. Output is the default listing here (rather
+ than the RTF destination); RTF-only footnote markup is omitted.
+**************************************************************************/
+
+  proc format;
+   value city
+     1 = 'Washington, DC'
+     2 = 'Baltimore'
+     3 = 'Boston'
+     4 = 'Detroit'
+     5 = 'Cleveland'
+     6 = 'Philadelphia'
+     7 = 'Milwaukee';
+  value $hht (notsorted)
+    '1' = 'Married-couple family'
+    '3' = 'Female-headed family'
+    other = 'Other';
+  value agep
+    0-<65 = 'Under 65'
+    65-high = '65+';
+  value educ
+    1-8 = 'No HS diploma'
+    9 = 'HS graduate'
+    10-12 = 'Some college'
+    13 = 'Bachelors degree'
+    14-16 = 'Advanced degree';
+  value $cit
+    '1','2','3' = 'Native born citizen'
+    '4' = 'Naturalized citizen'
+    '5' = 'Not a US citizen';
+  value pov
+    . = 'Unknown'
+    0 -< 50  = 'Below 50% poverty'
+    50 -< 100 = '50-99% poverty'
+    100 -< 200 = '100-199% poverty'
+    200 - high = '200% poverty or higher';
+run;
+
+%fdate
+
+options nodate nonumber missing='-';
+
+proc tabulate data=Acs_comp_table format=comma12.1 noseps missing;
+  class comp_city;
+  class hht / order=data preloadfmt;
+  class hhh_age hhh_educ hhh_citizen povpip;
+  var count num_hhs num_persons num_children num_adults hh_income hh_earnings
+      hh_has_earn hh_has_pub_assist hh_has_ssi num_work_adults num_work_ft_adults;
+  weight wgtp;
+  table
+    count='Number of children < 3 years old' * sum * f=comma12.0
+    num_hhs='Number of HHs w/children < 3 years old' * sum * f=comma12.0
+    num_persons='Avg. HH size' * mean
+    num_adults='Avg. num. adults/HH' * mean
+    hht='% Children by household type' * colpctsum * count=' '
+    hhh_age='% Children by age of HH head' * colpctsum * count=' '
+    hhh_educ='% Children by education of HH head' * colpctsum * count=' '
+    hhh_citizen='% Children by citizenship of HH head' * colpctsum * count=' '
+    num_work_adults='Avg. num. working adults/HH' * mean
+    num_work_ft_adults='Avg. num. FT working adults/HH' * mean
+    hh_income='Median HH income ($)' * median * f=comma12.0
+    hh_earnings='Median HH earnings ($)' * median * f=comma12.0
+    hh_has_earn='% HHs w/earnings' * mean
+    hh_has_pub_assist='% HHs w/pub. assistance' * mean
+    hh_has_ssi='% HHs w/SSI' * mean
+    povpip='% Children by poverty status' * colpctsum * count=' '
+    ,
+    comp_city=' '
+   ;
+  format comp_city city. hht $hht. hhh_age agep. hhh_educ educ. hhh_citizen $cit.
+         povpip pov.;
+  keylabel
+    sum=' '
+    mean=' '
+    median=' '
+    colpctsum=' ';
+  title1 "Characteristics of Children Under Age 3 Years and Their Households";
+  title2 "For Washington, D.C. and Comparison Cities, 2005";
+
+run;

--- a/jenner-check/t004_macro_read_seq_list/autoexec.sas
+++ b/jenner-check/t004_macro_read_seq_list/autoexec.sas
@@ -1,0 +1,24 @@
+options obs=100;
+
+/* --------------------------------------------------------------------
+   Bundle setup for the ACS Read_seq_list macro.
+
+   Read_seq_list (Macros/Read_seq_list.sas) drives Read_seq once per
+   sequence number in a space-delimited list. In the library, Read_seq
+   (Macros/Read_seq.sas) %includes the per-sequence e/m read programs
+   from &rootdir for the current &_state_ab and appends the resulting
+   table names to two accumulating macro variables.
+
+   For a self-contained run we set &_state_ab and provide a Read_seq
+   that performs the same list accumulation Read_seq.sas performs,
+   without the external %include of the per-sequence read programs
+   (those pull in raw Census summary-file extracts not shipped here).
+   Read_seq_list.sas itself runs verbatim below.
+   -------------------------------------------------------------------- */
+
+%let _state_ab = dc;
+
+%macro Read_seq( seqno );
+  %let table_file_e_list = &table_file_e_list SFe&seqno.&_state_ab.;
+  %let table_file_m_list = &table_file_m_list SFm&seqno.&_state_ab.;
+%mend Read_seq;

--- a/jenner-check/t004_macro_read_seq_list/expected.json
+++ b/jenner-check/t004_macro_read_seq_list/expected.json
@@ -1,0 +1,13 @@
+{
+  "_captured_at": "2026-06-17T19:20:22+07:00",
+  "_captured_run_id": "r_019ed58643257b028bac44d8b63244be",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "table_file_e_list = SFe0001dc SFe0002dc SFe0003dc SFe0119dc",
+    "table_file_m_list = SFm0001dc SFm0002dc SFm0003dc SFm0119dc",
+    "Wrote seq_lists (2 rows, 2 columns)."
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t004_macro_read_seq_list/expected/files.md
+++ b/jenner-check/t004_macro_read_seq_list/expected/files.md
@@ -1,0 +1,16 @@
+These URLs point to artifacts from one specific run (run_id below) and expire when that run is reaped. Re-running the bundle regenerates them.
+
+run_id: r_019ed58643257b028bac44d8b63244be
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 239 | https://api.jenneranalytics.com/v1/run/r_019ed58643257b028bac44d8b63244be/files/listing.txt?token=7f5bdb10cb2a49068caedccb308b25b3 |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| seq_lists | 2 | ['list_type', 'table_files'] | https://api.jenneranalytics.com/v1/run/r_019ed58643257b028bac44d8b63244be/datasets/seq_lists?token=7f5bdb10cb2a49068caedccb308b25b3 |
+

--- a/jenner-check/t004_macro_read_seq_list/expected/log.txt
+++ b/jenner-check/t004_macro_read_seq_list/expected/log.txt
@@ -1,0 +1,16 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: table_file_e_list = SFe0001dc SFe0002dc SFe0003dc SFe0119dc
+NOTE: table_file_m_list = SFm0001dc SFm0002dc SFm0003dc SFm0119dc
+NOTE: DATA seq_lists
+
+
+NOTE: Wrote seq_lists (2 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=seq_lists
+
+NOTE: PROC PRINT completed: 2 observations printed, 2 variables

--- a/jenner-check/t004_macro_read_seq_list/expected/output.txt
+++ b/jenner-check/t004_macro_read_seq_list/expected/output.txt
@@ -1,0 +1,6 @@
+                                     ACS summary-file table names by sequence list                                      
+
+list_type                               table_files
+estimates   SFe0001dc SFe0002dc SFe0003dc SFe0119dc
+margins     SFm0001dc SFm0002dc SFm0003dc SFm0119dc
+

--- a/jenner-check/t004_macro_read_seq_list/meta.json
+++ b/jenner-check/t004_macro_read_seq_list/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t004_macro_read_seq_list",
+  "source_file": "Macros/Read_seq_list.sas",
+  "source_blob_sha": "ee5a46616b64808d72e481c30c08a1132e06a3dc",
+  "source_commit": "1921d40523961ca3d6d0bfa2b8df87784713c8cc",
+  "tier": "real_macro_caller",
+  "notes": "Exercises the library's Read_seq_list macro (verbatim) over a list of ACS summary-file sequence numbers. Read_seq is provided as a list-accumulating substitute matching Read_seq.sas semantics, minus the external per-sequence %include of raw Census extracts not shipped in the repo."
+}

--- a/jenner-check/t004_macro_read_seq_list/script.sas
+++ b/jenner-check/t004_macro_read_seq_list/script.sas
@@ -1,0 +1,51 @@
+/**************************************************************************
+ Bundle:   t004_macro_read_seq_list
+ Source:   Macros/Read_seq_list.sas (NeighborhoodInfoDC/ACS)
+ Author:   P. Tatian (macro), bundled for Jenner compatibility check
+
+ The Read_seq_list macro definition below is the library's own code,
+ verbatim. It scans a space-delimited list of ACS summary-file sequence
+ numbers and calls Read_seq once per sequence, accumulating the e- and
+ m-table name lists. The caller and PROC PRINT exercise that loop.
+**************************************************************************/
+
+/** Macro Read_seq_list - Start Definition **/
+
+%macro Read_seq_list( seq_list );
+
+  %local i v;
+
+  %let table_file_e_list = ;
+  %let table_file_m_list = ;
+
+  %let i = 1;
+  %let v = %scan( &seq_list, &i, %str( ) );
+
+  %do %until ( &v = );
+
+    %Read_seq( &v )
+
+    %let i = %eval( &i + 1 );
+    %let v = %scan( &seq_list, &i, %str( ) );
+
+  %end;
+
+%mend Read_seq_list;
+
+/** End Macro Definition **/
+
+%Read_seq_list( 0001 0002 0003 0119 )
+
+%put NOTE: table_file_e_list =&table_file_e_list;
+%put NOTE: table_file_m_list =&table_file_m_list;
+
+data seq_lists;
+  length list_type $ 12 table_files $ 200;
+  list_type = 'estimates';   table_files = "&table_file_e_list";   output;
+  list_type = 'margins';     table_files = "&table_file_m_list";   output;
+run;
+
+proc print data=seq_lists noobs;
+  var list_type table_files;
+  title 'ACS summary-file table names by sequence list';
+run;

--- a/jenner-check/t005_acs_puma_to_place_format/autoexec.sas
+++ b/jenner-check/t005_acs_puma_to_place_format/autoexec.sas
@@ -1,0 +1,16 @@
+options obs=100;
+
+/* --------------------------------------------------------------------
+   Bundle setup for Puma_to_city_formats.
+
+   The library program reads a geocorr PUMA-to-place crosswalk through
+   a filevar-driven list of raw CSVs under D:\DCData\...\Raw and builds
+   the $pum0fpl correspondence format with the DCData %Data_to_format
+   macro (which generates a PROC FORMAT CNTLIN= step).
+
+   For a self-contained run the crosswalk rows are read from inline
+   DATALINES (same columns the program reads) and %Data_to_format is
+   replaced with the equivalent PROC FORMAT CNTLIN= step it produces.
+   The city-selection logic, key construction and place-code list are
+   the program's own, unchanged.
+   -------------------------------------------------------------------- */

--- a/jenner-check/t005_acs_puma_to_place_format/expected.json
+++ b/jenner-check/t005_acs_puma_to_place_format/expected.json
@@ -1,0 +1,13 @@
+{
+  "_captured_at": "2026-06-17T19:22:59+07:00",
+  "_captured_run_id": "r_019ed588bc657b80a135693b0307f0ea",
+  "status": "ok",
+  "exit_code": 0,
+  "log_contains": [
+    "DATA geocorr",
+    "PROC FORMAT",
+    "DATA demo"
+  ],
+  "log_does_not_contain": ["ERROR:", "[JENNER-ERROR"],
+  "diagnostics": {"parse_warnings": [], "runtime_warnings": []}
+}

--- a/jenner-check/t005_acs_puma_to_place_format/expected/files.md
+++ b/jenner-check/t005_acs_puma_to_place_format/expected/files.md
@@ -1,0 +1,18 @@
+These URLs point to artifacts from one specific run (run_id below) and expire when that run is reaped. Re-running the bundle regenerates them.
+
+run_id: r_019ed588bc657b80a135693b0307f0ea
+
+## Files
+
+| name | content_type | size_bytes | url |
+|---|---|---|---|
+| listing.txt | text/plain | 578 | https://api.jenneranalytics.com/v1/run/r_019ed588bc657b80a135693b0307f0ea/files/listing.txt?token=55450898fe9a42eaaa337bed83716b46 |
+
+## Datasets
+
+| name | rows | columns | preview_url |
+|---|---|---|---|
+| demo | 4 | ['upuma5', 'place'] | https://api.jenneranalytics.com/v1/run/r_019ed588bc657b80a135693b0307f0ea/datasets/demo?token=55450898fe9a42eaaa337bed83716b46 |
+| geocorr | 8 | ['statecd', 'placefp', 'stab', 'placenm', 'upuma5', 'uplacefp', 'puma5', 'pop2k', 'afact'] | https://api.jenneranalytics.com/v1/run/r_019ed588bc657b80a135693b0307f0ea/datasets/geocorr?token=55450898fe9a42eaaa337bed83716b46 |
+| pum0fpl_cntlin | 8 | ['fmtname', 'type', 'start', 'label'] | https://api.jenneranalytics.com/v1/run/r_019ed588bc657b80a135693b0307f0ea/datasets/pum0fpl_cntlin?token=55450898fe9a42eaaa337bed83716b46 |
+

--- a/jenner-check/t005_acs_puma_to_place_format/expected/log.txt
+++ b/jenner-check/t005_acs_puma_to_place_format/expected/log.txt
@@ -1,0 +1,45 @@
+Jenner 0.1.0 (Unlicensed - limited to 100 observations)
+Get a license at https://jenneranalytics.com/license
+
+NOTE: Option OBS changed to 100.
+NOTE: DATA geocorr
+
+NOTE: Processing inline DATALINES (10 lines)
+
+NOTE: Read 10 rows from DATALINES.
+NOTE: Wrote geocorr (8 rows, 9 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=geocorr
+
+NOTE: PROC PRINT completed: 8 observations printed, 3 variables
+NOTE: DATA pum0fpl_cntlin
+
+
+NOTE: Read 8 rows from geocorr.
+NOTE: Wrote pum0fpl_cntlin (8 rows, 4 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC SORT data=pum0fpl_cntlin
+
+NOTE: Unlicensed mode - input limited to 100 observations.
+NOTE: Read 8 rows from pum0fpl_cntlin.
+NOTE: Wrote pum0fpl_cntlin (8 rows, 4 columns).
+NOTE: PROC SORT statement used.
+NOTE: PROC FORMAT library=WORK
+
+NOTE: CNTLIN: Loaded 8 format entries from pum0fpl_cntlin
+NOTE: DATA demo
+
+NOTE: Processing inline DATALINES (4 lines)
+
+NOTE: Read 4 rows from DATALINES.
+NOTE: Wrote demo (4 rows, 2 columns).
+NOTE: DATA elapsed:
+  wall  0.00 seconds
+  cpu   0.00 seconds
+NOTE: PROC PRINT data=demo
+
+NOTE: PROC PRINT completed: 4 observations printed, 2 variables

--- a/jenner-check/t005_acs_puma_to_place_format/expected/output.txt
+++ b/jenner-check/t005_acs_puma_to_place_format/expected/output.txt
@@ -1,0 +1,20 @@
+                                         Selected PUMA-to-place crosswalk rows                                          
+
+  Obs   upuma5  uplacefp       placenm
+    1  1100102  1150000   Washington
+    2  2401002  2404000   Baltimore
+    3  2503301  2507000   Boston
+    4  2603201  2622000   Detroit
+    5  3901901  3916000   Cleveland
+    6  4204101  4260000   Philadelphia
+    7  5505301  5553000   Milwaukee
+    8  5105101  5101000   Alexandria
+
+                                    PUMA code translated to FIPS place via $pum0fpl                                     
+
+ upuma5    place
+1100102  1150000
+2401002  2404000
+2603201  2622000
+4204101  4260000
+

--- a/jenner-check/t005_acs_puma_to_place_format/meta.json
+++ b/jenner-check/t005_acs_puma_to_place_format/meta.json
@@ -1,0 +1,8 @@
+{
+  "bundle": "t005_acs_puma_to_place_format",
+  "source_file": "Prog/Puma_to_city_formats.sas",
+  "source_blob_sha": "d32ce7f3193e54c2a25f6478f10f2aae21fe19fc",
+  "source_commit": "1921d40523961ca3d6d0bfa2b8df87784713c8cc",
+  "tier": "real_data_substituted",
+  "notes": "Builds the program's $pum0fpl PUMA-to-FIPS-place correspondence format. City-selection list, unique-key construction (statecd||z5 PUMA, statecd||z5 place) and place codes are the program's own. Crosswalk rows are inline DATALINES (10 rows, 8 selected cities) standing in for the geocorr2k raw CSV; %Data_to_format replaced by the equivalent PROC FORMAT CNTLIN= it generates."
+}

--- a/jenner-check/t005_acs_puma_to_place_format/script.sas
+++ b/jenner-check/t005_acs_puma_to_place_format/script.sas
@@ -1,0 +1,97 @@
+/**************************************************************************
+ Bundle:   t005_acs_puma_to_place_format
+ Source:   Prog/Puma_to_city_formats.sas (NeighborhoodInfoDC/ACS)
+ Author:   P. Tatian, bundled for Jenner compatibility check
+
+ Build the $pum0fpl correspondence format that converts Census 2000
+ PUMA codes to FIPS place codes for the selected NeighborhoodInfo DC
+ comparison cities. The city filter, the unique-key construction and
+ the place-code list are the program's own; only the crosswalk source
+ (inline rows here) and the format-build step are adapted for a
+ self-contained run.
+**************************************************************************/
+
+data geocorr;
+
+  length statecd $ 2 placefp $ 5 stab $ 2 placenm $ 40;
+
+  input statecd $ placefp $ puma5 stab $ placenm $ pop2k afact;
+
+  placefp = put( 1 * placefp, z5. );
+
+  length upuma5 uplacefp $ 7;
+
+  upuma5 = statecd || put( puma5, z5. );
+  uplacefp = statecd || placefp;
+
+  ** Only keep selected cities **;
+
+  if uplacefp in (
+    "1150000",  /** Washington, DC **/
+    "2255000",  /** New Orleans **/
+    "2404000",  /** Baltimore **/
+    "2507000",  /** Boston **/
+    "2622000",  /** Detroit **/
+    "2965000",  /** St. Louis **/
+    "3916000",  /** Cleveland **/
+    "4260000",  /** Philadelphia **/
+    "5101000",  /** Alexandria city **/
+    "5103000",  /** Arlington CDP **/
+    "5553000"   /** Milwaukee **/
+    )
+    then output;
+
+  datalines;
+11 50000 102 DC Washington 572059 0.98
+24 04000 1002 MD Baltimore 651154 0.95
+25 07000 3301 MA Boston 589141 0.93
+26 22000 3201 MI Detroit 951270 0.91
+39 16000 1901 OH Cleveland 478403 0.90
+42 60000 4101 PA Philadelphia 1517550 0.97
+55 53000 5301 WI Milwaukee 596974 0.88
+51 01000 5101 VA Alexandria 128283 0.40
+17 14000 3501 IL Chicago 2896016 0.80
+06 44000 8001 CA LosAngeles 3694820 0.75
+;
+run;
+
+proc print data=geocorr;
+  var upuma5 uplacefp placenm;
+  title 'Selected PUMA-to-place crosswalk rows';
+run;
+
+/* %Data_to_format( FmtLib=ACS, FmtName=$pum0fpl, Value=upuma5,
+   Label=uplacefp, ... ) builds the format below via PROC FORMAT CNTLIN. */
+
+data pum0fpl_cntlin;
+  retain fmtname '$pum0fpl' type 'C';
+  set geocorr;
+  start = upuma5;
+  label = uplacefp;
+  keep fmtname type start label;
+run;
+
+proc sort data=pum0fpl_cntlin nodupkey;
+  by start;
+run;
+
+proc format cntlin=pum0fpl_cntlin;
+run;
+
+** Demonstrate the format converting PUMA codes to place codes **;
+
+data demo;
+  length upuma5 $ 7 place $ 7;
+  input upuma5 $;
+  place = put( upuma5, $pum0fpl. );
+  datalines;
+1100102
+2401002
+2603201
+4204101
+;
+run;
+
+proc print data=demo noobs;
+  title 'PUMA code translated to FIPS place via $pum0fpl';
+run;


### PR DESCRIPTION
[Jenneranalytics.com](https://jenneranalytics.com) provides an API that runs SAS code, with support for more than 200 SAS procedures. You can also use it with Anthropic Claude Code AI in a collaborative workspace. It's available for Mac on the Apple App Store, and by license for Windows and Linux.

Your ACS programs run on it unmodified. This PR adds a small `jenner-check/` folder with five self-contained compatibility bundles drawn from this library, so you can see your own code execute against the API.

```
jenner-check/
├── t001_acs_pums_merge/            # PUMS population × housing merge → _was / _comp split
├── t002_acs_children_hh/           # household roll-up for children under 3 (FIRST./LAST.)
├── t003_acs_comp_table/            # PROC TABULATE comparison-city report
├── t004_macro_read_seq_list/       # Read_seq_list sequence-number macro
├── t005_acs_puma_to_place_format/  # $pum0fpl PUMA → FIPS place format
└── run_jenner.sh                   # ./run_jenner.sh --all
```

Each bundle keeps your logic intact and supplies small inline data in place of the Census extracts and external libraries; `meta.json` records what was adapted. Run them all with `./run_jenner.sh --all`, or POST a single `script.sas` to the API directly.

The way `$pum0fpl` carries PUMA-to-place correspondence through the PUMS merge so the comparison-city split falls out cleanly is a genuinely tidy piece of design, and maintaining this much ACS history in one coherent, well-factored library is impressive.

Merge, close, or ignore as you see fit — no response expected. To opt out of any future messages, reply with `no-more-prs` in a comment or open an issue titled `jenner-check: opt out`.

---

Lawrence W. Sinclair  
CEO / Jenner Analytics Ltd  
[jenneranalytics.com](https://jenneranalytics.com)  
[linkedin.com/in/lwsinclair/](https://www.linkedin.com/in/lwsinclair/)
